### PR TITLE
PYTHON-4066: Adding MongoDB 2023 license

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1,6 +1,21 @@
+MongoDB uses third-party libraries or other resources that may be
+distributed under licenses different than the MongoDB software.
+
+In the event that we accidentally failed to list a required notice, please
+bring it to our attention by creating a pull-request or filing a github
+issue with the full-stack-fastapi-mongodb project.
+
+The attached notices are provided for information only.
+
+For any licenses that require disclosure of source, sources are available at
+https://github.com/mongodb-labs/full-stack-fastapi-mongodb.
+
+1) License notice for full-stack-fastapi-postgresql
+---------------------------------------------------
+
 MIT License
 
-Copyright (c) 2023 MongoDB Inc.
+Copyright (c) 2019 Sebastián Ramírez
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Description: https://jira.mongodb.org/browse/PYTHON-4066