### PR TITLE
fix: Corrected exclude parameter to accept valid arguments

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/schemas/base_schema.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/schemas/base_schema.py
@@ -11,7 +11,7 @@ from app.schema_types import BaseEnum
 class BaseSchema(BaseModel):
     @property
     def as_db_dict(self):
-        to_db = self.model_dump(exclude_defaults=True, exclude_none=True, exclude={"identifier, id"})
+        to_db = self.model_dump(exclude_defaults=True, exclude_none=True, exclude={"identifier", "id"})
         for key in ["id", "identifier"]:
             if key in self.model_dump().keys():
                 to_db[key] = self.model_dump()[key].hex


### PR DESCRIPTION
In the /backend/app/app/schemas/base_schema.py I found what is likely to be an error in the as_db_dict property of BaseSchema class. In the set literal {"identifier, id"} the correct syntax should probably use two separate strings in the set: {"identifier", "id"}. I did local tests and it seems not to affect the properties end result because the key "identifier" is overwritten anyway in this case. But model_dump() outputs a different result when using two separated string, ie: excluding the key "identifier" from the dumped model.