### PR TITLE
♻️ CODE REFACTOR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ testing-project
 dev-link/
 
 .DS_Store
+.idea/

--- a/{{cookiecutter.project_slug}}/backend/app/app/core/security.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/core/security.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, Union, Optional
+from typing import Any, Union
 
 from jose import jwt
 from passlib.context import CryptContext
@@ -64,7 +64,7 @@ def create_magic_tokens(*, subject: Union[str, Any], expires_delta: timedelta = 
     return magic_tokens
 
 
-def create_new_totp(*, label: str, uri: Optional[str] = None) -> NewTOTP:
+def create_new_totp(*, label: str, uri: str | None = None) -> NewTOTP:
     if not uri:
         totp = totp_factory.new()
     else:

--- a/{{cookiecutter.project_slug}}/backend/app/app/crud/base.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/crud/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Generic, Optional, Type, TypeVar, Union
+from typing import Any, Dict, Generic, Type, TypeVar, Union
 
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
@@ -27,20 +27,20 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         self.model = model
         self.engine: AIOEngine = get_engine()
 
-    async def get(self, db: AgnosticDatabase, id: Any) -> Optional[ModelType]:
+    async def get(self, db: AgnosticDatabase, id: Any) -> ModelType | None:
         return await self.engine.find_one(self.model, self.model.id == id)
 
-    async def get_multi(self, db: AgnosticDatabase, *, page: int = 0, page_break: bool = False) -> list[ModelType]:
-        offset = {"skip": page * settings.MULTI_MAX, "limit": settings.MULTI_MAX} if page_break else {}
+    async def get_multi(self, db: AgnosticDatabase, *, page: int = 0, page_break: bool = False) -> list[ModelType]: # noqa
+        offset = {"skip": page * settings.MULTI_MAX, "limit": settings.MULTI_MAX} if page_break else {} # noqa
         return await self.engine.find(self.model, **offset)
 
-    async def create(self, db: AgnosticDatabase, *, obj_in: CreateSchemaType) -> ModelType:
+    async def create(self, db: AgnosticDatabase, *, obj_in: CreateSchemaType) -> ModelType: # noqa
         obj_in_data = jsonable_encoder(obj_in)
         db_obj = self.model(**obj_in_data)  # type: ignore
         return await self.engine.save(db_obj)
 
     async def update(
-        self, db: AgnosticDatabase, *, db_obj: ModelType, obj_in: Union[UpdateSchemaType, Dict[str, Any]]
+        self, db: AgnosticDatabase, *, db_obj: ModelType, obj_in: Union[UpdateSchemaType, Dict[str, Any]] # noqa
     ) -> ModelType:
         obj_data = jsonable_encoder(db_obj)
         if isinstance(obj_in, dict):

--- a/{{cookiecutter.project_slug}}/backend/app/app/main.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/main.py
@@ -23,8 +23,9 @@ if settings.BACKEND_CORS_ORIGINS:
     app.add_middleware(
         CORSMiddleware,
         # Trailing slash causes CORS failures from these supported domains
-        allow_origins=[str(origin).rstrip("/") for origin in settings.BACKEND_CORS_ORIGINS],
+        allow_origins=[str(origin).strip("/") for origin in settings.BACKEND_CORS_ORIGINS], # noqa
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
     )
+

--- a/{{cookiecutter.project_slug}}/backend/app/app/models/user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/models/user.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 from datetime import datetime
 from pydantic import EmailStr
 from odmantic import ObjectId, Field
@@ -21,7 +21,7 @@ class User(Base):
     email: EmailStr
     hashed_password: Any = Field(default=None)
     totp_secret: Any = Field(default=None)
-    totp_counter: Optional[int] = Field(default=None)
+    totp_counter: int | None = Field(default=None)
     email_validated: bool = Field(default=False)
     is_active: bool = Field(default=False)
     is_superuser: bool = Field(default=False)

--- a/{{cookiecutter.project_slug}}/backend/app/app/schemas/base_schema.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/schemas/base_schema.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from pydantic import ConfigDict, BaseModel, Field
-from typing import Optional
 from uuid import UUID
 from datetime import date, datetime
 import json
@@ -11,7 +10,7 @@ from app.schema_types import BaseEnum
 class BaseSchema(BaseModel):
     @property
     def as_db_dict(self):
-        to_db = self.model_dump(exclude_defaults=True, exclude_none=True, exclude={"identifier", "id"})
+        to_db = self.model_dump(exclude_defaults=True, exclude_none=True, exclude={"identifier", "id"}) # noqa
         for key in ["id", "identifier"]:
             if key in self.model_dump().keys():
                 to_db[key] = self.model_dump()[key].hex
@@ -21,15 +20,15 @@ class BaseSchema(BaseModel):
 class MetadataBaseSchema(BaseSchema):
     # Receive via API
     # https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#section-3
-    title: Optional[str] = Field(None, description="A human-readable title given to the resource.")
-    description: Optional[str] = Field(
+    title: str | None = Field(None, description="A human-readable title given to the resource.") # noqa
+    description: str | None = Field(
         None,
         description="A short description of the resource.",
     )
-    isActive: Optional[bool] = Field(default=True, description="Whether the resource is still actively maintained.")
-    isPrivate: Optional[bool] = Field(
+    isActive: bool | None = Field(default=True, description="Whether the resource is still actively maintained.") # noqa
+    isPrivate: bool | None = Field(
         default=True,
-        description="Whether the resource is private to team members with appropriate authorisation.",
+        description="Whether the resource is private to team members with appropriate authorisation.",  # noqa
     )
 
 

--- a/{{cookiecutter.project_slug}}/backend/app/app/schemas/token.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/schemas/token.py
@@ -1,11 +1,10 @@
-from typing import Optional
 from pydantic import BaseModel, ConfigDict, SecretStr
 from odmantic import Model, ObjectId
 
 
 class RefreshTokenBase(BaseModel):
     token: SecretStr
-    authenticates: Optional[Model] = None
+    authenticates: Model | None = None
 
 
 class RefreshTokenCreate(RefreshTokenBase):
@@ -22,19 +21,19 @@ class RefreshToken(RefreshTokenUpdate):
 
 class Token(BaseModel):
     access_token: SecretStr
-    refresh_token: Optional[SecretStr] = None
+    refresh_token: SecretStr | None = None
     token_type: str
 
 
 class TokenPayload(BaseModel):
-    sub: Optional[ObjectId] = None
-    refresh: Optional[bool] = False
-    totp: Optional[bool] = False
+    sub: ObjectId | None = None
+    refresh: bool | None = False
+    totp: bool | None = False
 
 
 class MagicTokenPayload(BaseModel):
-    sub: Optional[ObjectId] = None
-    fingerprint: Optional[ObjectId] = None
+    sub: ObjectId | None = None
+    fingerprint: ObjectId | None = None
 
 
 class WebToken(BaseModel):

--- a/{{cookiecutter.project_slug}}/backend/app/app/schemas/totp.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/schemas/totp.py
@@ -1,9 +1,8 @@
-from typing import Optional
 from pydantic import BaseModel, SecretStr
 
 
 class NewTOTP(BaseModel):
-    secret: Optional[SecretStr] = None
+    secret: SecretStr | None = None
     key: str
     uri: str
 
@@ -11,4 +10,4 @@ class NewTOTP(BaseModel):
 class EnableTOTP(BaseModel):
     claim: str
     uri: str
-    password: Optional[SecretStr] = None
+    password: SecretStr | None = None

--- a/{{cookiecutter.project_slug}}/backend/app/app/schemas/user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/schemas/user.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from typing_extensions import Annotated
 from pydantic import BaseModel, ConfigDict, Field, EmailStr, StringConstraints, field_validator, SecretStr
 from odmantic import ObjectId
@@ -11,27 +10,27 @@ class UserLogin(BaseModel):
 
 # Shared properties
 class UserBase(BaseModel):
-    email: Optional[EmailStr] = None
-    email_validated: Optional[bool] = False
-    is_active: Optional[bool] = True
-    is_superuser: Optional[bool] = False
+    email: EmailStr | None = None
+    email_validated: bool | None = False
+    is_active: bool | None = True
+    is_superuser: bool | None = False
     full_name: str = ""
 
 
 # Properties to receive via API on creation
 class UserCreate(UserBase):
     email: EmailStr
-    password: Optional[Annotated[str, StringConstraints(min_length=8, max_length=64)]] = None
+    password: Annotated[str | None, StringConstraints(min_length=8, max_length=64)] = None # noqa
 
 
 # Properties to receive via API on update
 class UserUpdate(UserBase):
-    original: Optional[Annotated[str, StringConstraints(min_length=8, max_length=64)]] = None
-    password: Optional[Annotated[str, StringConstraints(min_length=8, max_length=64)]] = None
+    original: Annotated[str | None, StringConstraints(min_length=8, max_length=64)] = None # noqa
+    password: Annotated[str | None, StringConstraints(min_length=8, max_length=64)] = None  # noqa
 
 
 class UserInDBBase(UserBase):
-    id: Optional[ObjectId] = None
+    id: ObjectId | None = None
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -56,6 +55,6 @@ class User(UserInDBBase):
 
 # Additional properties stored in DB
 class UserInDB(UserInDBBase):
-    hashed_password: Optional[SecretStr] = None
-    totp_secret: Optional[SecretStr] = None
-    totp_counter: Optional[int] = None
+    hashed_password: SecretStr | None = None
+    totp_secret: SecretStr | None = None
+    totp_counter: int | None = None


### PR DESCRIPTION
1. refactored backend_cors_origin field in config to use annotated and BeforeValidator instead of the field validator decorator anymore and changed from rstrip to strip in main when calling backend_cors_origin

2. move from *Optional[Type] = None* to *Type | None  = None*, This proposed change is well an argument but the below discussion link is a clarification to [PEP 604 – Allow writing union types as X | Y](https://peps.python.org/pep-0604/)
[Python discussion](https://discuss.python.org/t/clarification-for-pep-604-is-foo-int-none-to-replace-all-use-of-foo-optional-int/26945)