### PR TITLE
[Bugfix]: Remove usage of Union-Type in odmantic modeling.

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/models/user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/models/user.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 from datetime import datetime
 from pydantic import EmailStr
 from odmantic import ObjectId, Field
@@ -21,7 +21,7 @@ class User(Base):
     email: EmailStr
     hashed_password: Any = Field(default=None)
     totp_secret: Any = Field(default=None)
-    totp_counter: int | None = Field(default=None)
+    totp_counter: Optional[int] = Field(default=None)
     email_validated: bool = Field(default=False)
     is_active: bool = Field(default=False)
     is_superuser: bool = Field(default=False)


### PR DESCRIPTION
Summary
Problem: The backend container fails to load with the error types.Uniontype is not subscriptable.
Root Cause: the User(Base) model of app/app/models/user.py doesn't support the types.UnionType operation. The Base class is an odmantic.Model type and https://github.com/art049/odmantic/issues/399 that is where the error is occurring. I'm putting up a fix to switch that back to Optional[int].
Fix: Switch to Optional[int] for the Unit type

Reference Issue: #41 