### PR TITLE
Fix react-dom version conflict

### DIFF
--- a/{{cookiecutter.project_slug}}/frontend/package.json
+++ b/{{cookiecutter.project_slug}}/frontend/package.json
@@ -24,7 +24,7 @@
     "prettier": "^3.1.1",
     "qrcode.react": "^3.1.0",
     "react": "18.2.0",
-    "react-dom": "latest",
+    "react-dom": "18.2.0",
     "react-hook-form": "^7.46.2",
     "react-redux": "^8.1.2",
     "redux": "latest",


### PR DESCRIPTION
React and react-dom must be at the same version. This fixes the `docker compose build` step.