### PR TITLE
[Bugfix] Remove SecretStr from Token Schema

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/schemas/token.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/schemas/token.py
@@ -20,8 +20,8 @@ class RefreshToken(RefreshTokenUpdate):
 
 
 class Token(BaseModel):
-    access_token: SecretStr
-    refresh_token: SecretStr | None = None
+    access_token: str
+    refresh_token: str | None = None
     token_type: str
 
 


### PR DESCRIPTION
## Bugfix

```python
class Token(BaseModel):
    access_token: SecretStr
    refresh_token: SecretStr
    token_type: str
```

Caused errors when transmitting a payload to the frontend. The frontend subsequently read the input as `access_token: '*****'` making users unable to leverage the login functionality. This fix returns the it back to using str.  