### PR TITLE
INTPYTHON-956: Update deployment scripts and documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ You can go to that directory with a full new project, edit files and test things
 ```console
 $ cd ./dev-fsfp/
 
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 It is outside of the project generator directory to let you add Git to it and compare versions and changes.
@@ -53,7 +53,7 @@ To discard all those changes at once, run `discard-dev-files.sh` from the root o
 ```console
 $ cd ~/code/full-stack-fastapi-mongodb/
 
-$ bash ./scripts/dev-fsfp-back.sh
+$ bash ./scripts/discard-dev-files.sh
 ```
 
 * `./scripts/test.sh`:

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -44,7 +44,7 @@ This guide uses [DigitalOcean Droplets](https://www.digitalocean.com/pricing/dro
 
 Ensure you add your SSH encryption keys on launch so that your server can be secure from the beginning.
 
-Deploy on whatever server image your prefer, although the default would be Ubuntu 20.04 (22.04 is the latest). End-of-life for 20.04 is April 2030, and for 22.04 is April 2032. You have time. The underlying image isn't that critical, as you'll be using the Docker images at their current versions.
+Deploy on whatever server image you prefer, although the default would be Ubuntu 22.04 (24.04 is the latest). End-of-life for 22.04 is April 2032, and for 24.04 is April 2034. The underlying image isn't that critical, as you'll be using the Docker images at their current versions.
 
 ### Domain name and email
 
@@ -83,7 +83,7 @@ rm get-docker.sh
 
 ### Clone your repository
 
-The basic approach is to clone from GitHub then set up the appropriate `.env` files and any custom `conf` files called from `docker-compose`. If yours is a private repo, review the GitHub docs for how to set that up.
+The basic approach is to clone from GitHub then set up the appropriate `.env` files and any custom `conf` files called from `docker compose`. If yours is a private repo, review the GitHub docs for how to set that up.
 
 Remember you can create new passwords as follows:
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -83,16 +83,16 @@ cookiecutter https://github.com/mongodb-labs/full-stack-fastapi-mongodb.git
 
 Once the Cookiecutter script has completed, you will have a folder populated with the base project and all input variables customized. 
 
-Change into the project folder and run the `docker-compose` script to build the project containers:
+Change into the project folder and run `docker compose` to build the project containers:
 
 ```bash
-docker-compose build --no-cache
+docker compose build --no-cache
 ```
 
 And start them:
 
 ```bash
-docker-compose up -d 
+docker compose up -d
 ```
 
 Your Docker Desktop app should look like this:
@@ -123,8 +123,8 @@ $ code .
 Change into the `/frontend` folder, and:
 
 ```bash
-yarn install
-yarn dev
+npm install
+npm run dev
 ```
 
 FastAPI `backend` updates will refresh automatically, but the `celeryworker` container must be restarted before changes take effect.
@@ -134,7 +134,7 @@ FastAPI `backend` updates will refresh automatically, but the `celeryworker` con
 If you like to do algorithmic development and testing in Jupyter Notebooks, then launch the `backend` terminal and start Jupyter as follows:
 
 ```bash
-docker-compose exec backend bash
+docker compose exec backend bash
 ```
 
 From the terminal:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,7 +33,6 @@ This FastAPI, React, MongoDB repo will generate a complete web application stack
   - [**Many other features**]("https://fastapi.tiangolo.com/features/"): including automatic validation, serialization, interactive documentation, etc.
 - [**Nextjs/React**](https://nextjs.org/) frontend:
   - **Authorization** route-based authentication, including support for detecting if a user is logged in or is a superuser.
-  - **Model blog** project, with [Nuxt Content](https://content.nuxtjs.org/) for writing Markdown pages.
   - **Form validation** with [React useForm](https://react-hook-form.com/docs/useform)
   - **State management** with [Redux](https://redux.js.org/)
   - **CSS and templates** with [TailwindCSS](https://tailwindcss.com/), [HeroIcons](https://heroicons.com/), and [HeadlessUI](https://headlessui.com/).

--- a/docs/websocket-guide.md
+++ b/docs/websocket-guide.md
@@ -58,128 +58,126 @@ If the user is joining a multi-user session, then each update to the session is 
 pip install websockets
 ```
 
-- There are multiple JavaScript libraries for Websockets, but I like [WebSocketAs Promised](https://github.com/vitalets/websocket-as-promised#readme):
-
-```
-yarn install websocket-as-promised
-```
+- The frontend uses the browser's native [WebSocket API](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) — no additional packages required.
 
 ## Setting up the React `frontend`
 
-The API `backend` is reached at `ws://localhost/api/v1` (or `wss://<your-domain>/api/v1` in production).
+The WebSocket backend is reached by converting your `NEXT_PUBLIC_API_URL` from `http` to `ws` (or `https` to `wss` in production). The connection is managed in a `useRef` so it persists across renders without triggering re-renders.
 
-Create an appropriate `websocketAPI.ts` file:
+In the relevant `page.tsx` (or component):
 
-```
-import WebSocketAsPromised from "websocket-as-promised"
-import { apiCore } from "./core"
+```typescript
+"use client";
 
-export const apiSockets = {
-  socketRequest() {
-    return new WebSocketAsPromised(`${apiCore.wsurl()}/socket`, {
-      packMessage: (data) => JSON.stringify(data),
-      unpackMessage: (data) => JSON.parse(data as string),
-    })
-  },
+import { useEffect, useRef, useState } from "react";
+import { useAppDispatch, useAppSelector } from "../lib/hooks";
+import { token, refreshTokens } from "../lib/slices/tokensSlice";
+import { addNotice } from "../lib/slices/toastsSlice";
+import { RootState } from "../lib/store";
+
+interface ISocketResponse {
+  state: string;
+  data: Record<string, unknown>;
+  error?: string;
+}
+
+interface ISocketRequest {
+  state: string;
+  data: Record<string, unknown>;
+}
+
+export default function SocketPage() {
+  const dispatch = useAppDispatch();
+  const accessToken = useAppSelector((state: RootState) => token(state));
+  const wsRef = useRef<WebSocket | null>(null);
+  const [streaming, setStreaming] = useState(false);
+
+  function sendSocketRequest(state: string, data: Record<string, unknown>) {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      const payload: ISocketRequest = { state, data };
+      wsRef.current.send(JSON.stringify(payload));
+    }
+  }
+
+  function watchRequestSocket(request: ISocketRequest) {
+    switch (request.state) {
+      case "something":
+        // Request-specific options
+        break;
+      default:
+        sendSocketRequest(request.state, request.data);
+    }
+  }
+
+  function watchResponseSocket(response: ISocketResponse) {
+    // response: { state, data, error }
+    switch (response.state) {
+      case "initialised":
+        // User session is authenticated and you can now launch the process
+        watchRequestSocket({ state: "startThings", data: {} });
+        break;
+      case "somethingHappened":
+        // Do stuff
+        break;
+      case "somethingElse":
+        // Do some other stuff
+        break;
+      case "error":
+        dispatch(
+          addNotice({
+            title: "Some error",
+            content: `Error: ${response.error}`,
+            icon: "error",
+          }),
+        );
+        break;
+    }
+  }
+
+  useEffect(() => {
+    async function initialiseSocket() {
+      await dispatch(refreshTokens());
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "";
+      const wsUrl = apiUrl.replace(/^http/, "ws");
+      const ws = new WebSocket(`${wsUrl}/socket`);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        // Deliberately sending a user token to authenticate the session
+        ws.send(JSON.stringify({ token: accessToken }));
+        setStreaming(true);
+      };
+
+      ws.onmessage = (event) => {
+        const response = JSON.parse(event.data as string) as ISocketResponse;
+        watchResponseSocket(response);
+      };
+
+      ws.onerror = () => {
+        dispatch(
+          addNotice({
+            title: "Connection error",
+            content: "WebSocket connection failed.",
+            icon: "error",
+          }),
+        );
+      };
+    }
+
+    initialiseSocket();
+
+    // Close the socket when the component unmounts or the user navigates away
+    return () => {
+      if (wsRef.current) {
+        wsRef.current.close();
+        setStreaming(false);
+      }
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return <div>{/* page content */}</div>;
 }
 ```
-
-Then, in the relevant `page.ts` (or component), you create a `websocket` variable (`wsp`) and attach a `watcher` to it so that you can respond to events as it is updated:
-
-```
-<script setup lang="ts">
-	import WebSocketAsPromised from "websocket-as-promised"
-	import { IKeyable, ISocketRequest, ISocketResponse } from "@/interfaces"
-	import { apiSockets } from "@/api"
-	import { useAuthStore } from "@/stores"
-
-	// SETUP
-	let wsp = {} as WebSocketAsPromised
-	const authStore = useAuthStore()
-	const streaming = ref(false)
-
-	onMounted(async () => {
-	  await authStore.refreshTokens()
-	  await initialiseSocket()
-	})
-
-	async function initialiseSocket() {
-	  wsp = apiSockets.socketRequest()
-	  await wsp.open()
-	  wsp.onUnpackedMessage.addListener((data) => watchResponseSocket(data))
-	  // Deliberately sending a user token to authenticate the session
-	  const jsonData: IKeyable = {
-	    token: authStore.authTokens.token
-	  }
-	  wsp.sendPacked(jsonData)
-	  streaming.value = true
-	}
-	
-	function closeSocket() {
-	  wsp.onUnpackedMessage.removeListener((data) => watchResponseSocket(data))
-	  if (streaming.value) {
-	    wsp.close()
-	    streaming.value = false
-	  }
-	}
-	
-	onBeforeRouteLeave((to, from, next) => {
-	  closeSocket()
-	  next()
-	})
-
-	// SESSION
-	async function watchResponseSocket(response: ISocketResponse) {
-	  // response: { state, data, error }
-	  console.log("response: ", response.state, response.data)
-	  switch (response.state) {
-	    case "initialised":
-	      // User session is authenticated and you can now launch the process
-	      await watchRequestSocket({
-	        state: "startThings",
-	        data: {}
-	      })
-	      break
-	    case "somethingHappened":
-	      // Do stuff
-	      break
-	    case "somethingElse":
-	      // Do some other stuff
-	      break
-	    case "error":
-	      toast.addNotice({
-	        title: "Some error",
-	        content: `Error: ${response.error}`,
-	        icon: "error"
-	      })
-	      break
-	  }
-	}
-	
-	async function watchRequestSocket(request: ISocketRequest) {
-	  // request: { state, data }
-	  switch (request.state) {
-	    case "something":
-	      // Request-specific options
-	      break
-	    default:
-	      sendSocketRequest(request.state, request.data)
-	  }
-	}
-	
-	function sendSocketRequest(state: string, data: IKeyable) {
-	  try {
-	    const payload: ISocketRequest = {
-	      state,
-	      data
-	    }
-	    wsp.sendPacked(payload)
-	  } catch (e) {
-	    console.log(e)
-	    // closeSocket()
-	  }
-	}
-</script>
 ```
 
 The `response` is a `switch` statement which identifies and responds to the appropriate event. 

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -26,13 +26,13 @@ Traefik UI, to see how the routes are being handled by the proxy: http://localho
 To check the logs, run:
 
 ```bash
-docker-compose logs
+docker compose logs
 ```
 
 To check the logs of a specific service, add the name of the service, e.g.:
 
 ```bash
-docker-compose logs backend
+docker compose logs backend
 ```
 
 If your Docker is not running in `localhost` (the URLs above wouldn't work) check the sections below on **Development with Docker Toolbox** and **Development with a custom IP**.
@@ -95,7 +95,7 @@ The changes to that file only affect the local development environment, not the 
 For example, the directory with the backend code is mounted as a Docker "host volume", mapping the code you change live to the directory inside the container. That allows you to test your changes right away, without having to build the Docker image again. It should only be done during development, for production, you should build the Docker image with a recent version of the backend code. But during development, it allows you to iterate very fast. Have in mind that if you have a syntax error and save the Python file, it will break and exit, and the container will stop. After that, you can restart the container by fixing the error and running again:
 
 ```console
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 There is also a commented out `command` override, you can uncomment it and comment the default one. It makes the backend container run a process that does "nothing", but keeps the container alive. That allows you to get inside your running container and execute commands inside, for example a Python interpreter to test installed dependencies, or start the development server that reloads when it detects changes, or start a Jupyter Notebook session.
@@ -103,13 +103,13 @@ There is also a commented out `command` override, you can uncomment it and comme
 To get inside the container with a `bash` session you can start the stack with:
 
 ```console
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 and then `exec` inside the running container:
 
 ```console
-$ docker-compose exec backend bash
+$ docker compose exec backend bash
 ```
 
 You should see an output like:
@@ -147,7 +147,7 @@ The `./backend/app` directory is mounted as a "host volume" inside the docker co
 You can rerun the test on live code:
 
 ```Bash
-docker-compose exec backend /app/tests-start.sh
+docker compose exec backend /app/tests-start.sh
 ```
 
 #### Test running stack
@@ -155,7 +155,7 @@ docker-compose exec backend /app/tests-start.sh
 If your stack is already up and you just want to run the tests, you can use:
 
 ```bash
-docker-compose exec backend /app/tests-start.sh
+docker compose exec backend /app/tests-start.sh
 ```
 
 That `/app/tests-start.sh` script just calls `pytest` after making sure that the rest of the stack is running. If you need to pass extra arguments to `pytest`, you can pass them to that command and they will be forwarded.
@@ -163,7 +163,7 @@ That `/app/tests-start.sh` script just calls `pytest` after making sure that the
 For example, to stop on first error:
 
 ```bash
-docker-compose exec backend bash /app/tests-start.sh -x
+docker compose exec backend bash /app/tests-start.sh -x
 ```
 
 #### Test Coverage
@@ -179,7 +179,7 @@ DOMAIN=backend sh ./scripts/test-local.sh --cov-report=html
 To run the tests in a running stack with coverage HTML reports:
 
 ```bash
-docker-compose exec backend bash /app/tests-start.sh --cov-report=html
+docker compose exec backend bash /app/tests-start.sh --cov-report=html
 ```
 
 ### Live development with Python Jupyter Notebooks
@@ -191,7 +191,7 @@ The `docker-compose.override.yml` file sends a variable `env` with a value `dev`
 So, you can enter into the running Docker container:
 
 ```bash
-docker-compose exec backend bash
+docker compose exec backend bash
 ```
 
 And use the environment variable `$JUPYTER` to run a Jupyter Notebook with everything configured to listen on the public port (so that you can use it from your browser).
@@ -304,24 +304,22 @@ DOMAIN=localhost.tiangolo.com
 
 That variable will be used by the Docker Compose files.
 
-* Now open the file located at `./frontend/.env`. It would have a line like:
+* Now open the file located at `./frontend/.env.local`. It would have a line like:
 
 ```
-VUE_APP_DOMAIN_DEV=localhost
+NEXT_PUBLIC_API_URL=http://localhost/api/v1
 ```
 
 * Change that line to the domain you are going to use, e.g.:
 
 ```
-VUE_APP_DOMAIN_DEV=localhost.tiangolo.com
+NEXT_PUBLIC_API_URL=http://localhost.tiangolo.com/api/v1
 ```
-
-That variable will make your frontend communicate with that domain when interacting with your backend API, when the other variable `VUE_APP_ENV` is set to `development`.
 
 After changing the two lines, you can re-start your stack with:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 and check all the corresponding available URLs in the section at the end.
@@ -545,7 +543,7 @@ If you change your mind and, for example, want to deploy everything to a differe
 
 #### Deployment Technical Details
 
-Building and pushing is done with the `docker-compose.yml` file, using the `docker-compose` command. The file `docker-compose.yml` uses the file `.env` with default environment variables. And the scripts set some additional environment variables as well.
+Building and pushing is done with the `docker-compose.yml` file, using the `docker compose` command. The file `docker-compose.yml` uses the file `.env` with default environment variables. And the scripts set some additional environment variables as well.
 
 The deployment requires using `docker stack` instead of `docker-swarm`, and it can't read environment variables or `.env` files. Because of that, the `deploy.sh` script generates a file `docker-stack.yml` with the configurations from `docker-compose.yml` and injecting the environment variables in it. And then uses it to deploy the stack.
 
@@ -558,8 +556,8 @@ TAG=${TAG?Variable not set} \
 # Set the environment variable FRONTEND_ENV to the same value passed to this script with
 # a default value of "production" if nothing else was passed
 FRONTEND_ENV=${FRONTEND_ENV-production?Variable not set} \
-# The actual comand that does the work: docker-compose
-docker-compose \
+# The actual command that does the work: docker compose
+docker compose \
 # Pass the file that should be used, setting explicitly docker-compose.yml avoids the
 # default of also using docker-compose.override.yml
 -f docker-compose.yml \
@@ -597,17 +595,17 @@ Support for the deployment to the desired host domain has been commented out as 
 
 ## Docker Compose files and env vars
 
-There is a main `docker-compose.yml` file with all the configurations that apply to the whole stack, it is used automatically by `docker-compose`.
+There is a main `docker-compose.yml` file with all the configurations that apply to the whole stack, it is used automatically by `docker compose`.
 
-And there's also a `docker-compose.override.yml` with overrides for development, for example to mount the source code as a volume. It is used automatically by `docker-compose` to apply overrides on top of `docker-compose.yml`.
+And there's also a `docker-compose.override.yml` with overrides for development, for example to mount the source code as a volume. It is used automatically by `docker compose` to apply overrides on top of `docker-compose.yml`.
 
 These Docker Compose files use the `.env` file containing configurations to be injected as environment variables in the containers.
 
-They also use some additional configurations taken from environment variables set in the scripts before calling the `docker-compose` command.
+They also use some additional configurations taken from environment variables set in the scripts before calling the `docker compose` command.
 
 It is all designed to support several "stages", like development, building, testing, and deployment. Also, allowing the deployment to different environments like staging and production (and you can add more environments very easily).
 
-They are designed to have the minimum repetition of code and configurations, so that if you need to change something, you have to change it in the minimum amount of places. That's why files use environment variables that get auto-expanded. That way, if for example, you want to use a different domain, you can call the `docker-compose` command with a different `DOMAIN` environment variable instead of having to change the domain in several places inside the Docker Compose files.
+They are designed to have the minimum repetition of code and configurations, so that if you need to change something, you have to change it in the minimum amount of places. That's why files use environment variables that get auto-expanded. That way, if for example, you want to use a different domain, you can call the `docker compose` command with a different `DOMAIN` environment variable instead of having to change the domain in several places inside the Docker Compose files.
 
 Also, if you want to have another deployment environment, say `preprod`, you just have to change environment variables, but you can keep using the same Docker Compose files.
 
@@ -635,8 +633,6 @@ Automatic Interactive Docs (Swagger UI): https://{{cookiecutter.domain_main}}/do
 
 Automatic Alternative Docs (ReDoc): https://{{cookiecutter.domain_main}}/redoc
 
-PGAdmin: https://pgadmin.{{cookiecutter.domain_main}}
-
 Flower: https://flower.{{cookiecutter.domain_main}}
 
 ### Staging URLs
@@ -651,8 +647,6 @@ Automatic Interactive Docs (Swagger UI): https://{{cookiecutter.domain_staging}}
 
 Automatic Alternative Docs (ReDoc): https://{{cookiecutter.domain_staging}}/redoc
 
-PGAdmin: https://pgadmin.{{cookiecutter.domain_staging}}
-
 Flower: https://flower.{{cookiecutter.domain_staging}}
 
 ### Development URLs
@@ -666,8 +660,6 @@ Backend: http://localhost/api/
 Automatic Interactive Docs (Swagger UI): https://localhost/docs
 
 Automatic Alternative Docs (ReDoc): https://localhost/redoc
-
-PGAdmin: http://localhost:5050
 
 Flower: http://localhost:5555
 
@@ -685,8 +677,6 @@ Automatic Interactive Docs (Swagger UI): https://local.dockertoolbox.tiangolo.co
 
 Automatic Alternative Docs (ReDoc): https://local.dockertoolbox.tiangolo.com/redoc
 
-PGAdmin: http://local.dockertoolbox.tiangolo.com:5050
-
 Flower: http://local.dockertoolbox.tiangolo.com:5555
 
 Traefik UI: http://local.dockertoolbox.tiangolo.com:8090
@@ -703,8 +693,6 @@ Automatic Interactive Docs (Swagger UI): https://dev.{{cookiecutter.domain_main}
 
 Automatic Alternative Docs (ReDoc): https://dev.{{cookiecutter.domain_main}}/redoc
 
-PGAdmin: http://dev.{{cookiecutter.domain_main}}:5050
-
 Flower: http://dev.{{cookiecutter.domain_main}}:5555
 
 Traefik UI: http://dev.{{cookiecutter.domain_main}}:8090
@@ -720,8 +708,6 @@ Backend: http://localhost.tiangolo.com/api/
 Automatic Interactive Docs (Swagger UI): https://localhost.tiangolo.com/docs
 
 Automatic Alternative Docs (ReDoc): https://localhost.tiangolo.com/redoc
-
-PGAdmin: http://localhost.tiangolo.com:5050
 
 Flower: http://localhost.tiangolo.com:5555
 
@@ -740,7 +726,7 @@ You can check the variables used during generation in the file `cookiecutter-con
 
 You can generate the project again with the same configurations used the first time.
 
-That would be useful if, for example, the project generator (`tiangolo/full-stack-fastapi-postgresql`) was updated and you wanted to integrate or review the changes.
+That would be useful if, for example, the project generator (`mongodb-labs/full-stack-fastapi-mongodb`) was updated and you wanted to integrate or review the changes.
 
 You could generate a new project with the same configurations as this one in a parallel directory. And compare the differences between the two, without having to overwrite your current code but being able to use the same variables used for your current project.
 

--- a/{{cookiecutter.project_slug}}/backend/app/README.md
+++ b/{{cookiecutter.project_slug}}/backend/app/README.md
@@ -4,18 +4,18 @@
 
 * [Docker](https://www.docker.com/).
 * [Docker Compose](https://docs.docker.com/compose/install/).
-* [Poetry](https://python-poetry.org/) for Python package and environment management.
+* [Hatch](https://hatch.pypa.io/latest/) for Python package and environment management.
 
 ## Frontend Requirements
 
-* Node.js (with `yarn`).
+* Node.js (with `npm`).
 
 ## Backend local development
 
 * Start the stack with Docker Compose:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 * Now you can open your browser and interact with these URLs:
@@ -37,13 +37,13 @@ Traefik UI, to see how the routes are being handled by the proxy: http://localho
 To check the logs, run:
 
 ```bash
-docker-compose logs
+docker compose logs
 ```
 
 To check the logs of a specific service, add the name of the service, e.g.:
 
 ```bash
-docker-compose logs backend
+docker compose logs backend
 ```
 
 If your Docker is not running in `localhost` (the URLs above wouldn't work) check the sections below on **Development with Docker Toolbox** and **Development with a custom IP**.
@@ -107,7 +107,7 @@ The changes to that file only affect the local development environment, not the 
 For example, the directory with the backend code is mounted as a Docker "host volume", mapping the code you change live to the directory inside the container. That allows you to test your changes right away, without having to build the Docker image again. It should only be done during development, for production, you should build the Docker image with a recent version of the backend code. But during development, it allows you to iterate very fast. Have in mind that if you have a syntax error and save the Python file, it will break and exit, and the container will stop. After that, you can restart the container by fixing the error and running again:
 
 ```console
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 There is also a commented out `command` override, you can uncomment it and comment the default one. It makes the backend container run a process that does "nothing", but keeps the container alive. That allows you to get inside your running container and execute commands inside, for example a Python interpreter to test installed dependencies, or start the development server that reloads when it detects changes, or start a Jupyter Notebook session.
@@ -115,13 +115,13 @@ There is also a commented out `command` override, you can uncomment it and comme
 To get inside the container with a `bash` session you can start the stack with:
 
 ```console
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 and then `exec` inside the running container:
 
 ```console
-$ docker-compose exec backend bash
+$ docker compose exec backend bash
 ```
 
 You should see an output like:
@@ -157,7 +157,7 @@ The `./backend/app` directory is mounted as a "host volume" inside the docker co
 You can rerun the test on live code:
 
 ```Bash
-docker-compose exec backend /app/tests-start.sh
+docker compose exec backend /app/tests-start.sh
 ```
 
 #### Test running stack
@@ -165,7 +165,7 @@ docker-compose exec backend /app/tests-start.sh
 If your stack is already up and you just want to run the tests, you can use:
 
 ```bash
-docker-compose exec backend /app/tests-start.sh
+docker compose exec backend /app/tests-start.sh
 ```
 
 That `/app/tests-start.sh` script just calls `pytest` after making sure that the rest of the stack is running. If you need to pass extra arguments to `pytest`, you can pass them to that command and they will be forwarded.
@@ -173,7 +173,7 @@ That `/app/tests-start.sh` script just calls `pytest` after making sure that the
 For example, to stop on first error:
 
 ```bash
-docker-compose exec backend bash /app/tests-start.sh -x
+docker compose exec backend bash /app/tests-start.sh -x
 ```
 
 #### Test Coverage
@@ -189,7 +189,7 @@ DOMAIN=backend sh ./scripts/test-local.sh --cov-report=html
 To run the tests in a running stack with coverage HTML reports:
 
 ```bash
-docker-compose exec backend bash /app/tests-start.sh --cov-report=html
+docker compose exec backend bash /app/tests-start.sh --cov-report=html
 ```
 
 ### Live development with Python Jupyter Notebooks
@@ -201,7 +201,7 @@ The `docker-compose.override.yml` file sends a variable `env` with a value `dev`
 So, you can enter into the running Docker container:
 
 ```bash
-docker-compose exec backend bash
+docker compose exec backend bash
 ```
 
 And use the environment variable `$JUPYTER` to run a Jupyter Notebook with everything configured to listen on the public port (so that you can use it from your browser).
@@ -314,24 +314,22 @@ DOMAIN=localhost.tiangolo.com
 
 That variable will be used by the Docker Compose files.
 
-* Now open the file located at `./frontend/.env`. It would have a line like:
+* Now open the file located at `./frontend/.env.local`. It would have a line like:
 
 ```
-VUE_APP_DOMAIN_DEV=localhost
+NEXT_PUBLIC_API_URL=http://localhost/api/v1
 ```
 
 * Change that line to the domain you are going to use, e.g.:
 
 ```
-VUE_APP_DOMAIN_DEV=localhost.tiangolo.com
+NEXT_PUBLIC_API_URL=http://localhost.tiangolo.com/api/v1
 ```
-
-That variable will make your frontend communicate with that domain when interacting with your backend API, when the other variable `VUE_APP_ENV` is set to `development`.
 
 After changing the two lines, you can re-start your stack with:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 and check all the corresponding available URLs in the section at the end.
@@ -555,7 +553,7 @@ If you change your mind and, for example, want to deploy everything to a differe
 
 #### Deployment Technical Details
 
-Building and pushing is done with the `docker-compose.yml` file, using the `docker-compose` command. The file `docker-compose.yml` uses the file `.env` with default environment variables. And the scripts set some additional environment variables as well.
+Building and pushing is done with the `docker-compose.yml` file, using the `docker compose` command. The file `docker-compose.yml` uses the file `.env` with default environment variables. And the scripts set some additional environment variables as well.
 
 The deployment requires using `docker stack` instead of `docker-swarm`, and it can't read environment variables or `.env` files. Because of that, the `deploy.sh` script generates a file `docker-stack.yml` with the configurations from `docker-compose.yml` and injecting the environment variables in it. And then uses it to deploy the stack.
 
@@ -568,8 +566,8 @@ TAG=${TAG?Variable not set} \
 # Set the environment variable FRONTEND_ENV to the same value passed to this script with
 # a default value of "production" if nothing else was passed
 FRONTEND_ENV=${FRONTEND_ENV-production?Variable not set} \
-# The actual comand that does the work: docker-compose
-docker-compose \
+# The actual command that does the work: docker compose
+docker compose \
 # Pass the file that should be used, setting explicitly docker-compose.yml avoids the
 # default of also using docker-compose.override.yml
 -f docker-compose.yml \
@@ -605,17 +603,17 @@ If you need to add more environments, for example, you could imagine using a cli
 
 ## Docker Compose files and env vars
 
-There is a main `docker-compose.yml` file with all the configurations that apply to the whole stack, it is used automatically by `docker-compose`.
+There is a main `docker-compose.yml` file with all the configurations that apply to the whole stack, it is used automatically by `docker compose`.
 
-And there's also a `docker-compose.override.yml` with overrides for development, for example to mount the source code as a volume. It is used automatically by `docker-compose` to apply overrides on top of `docker-compose.yml`.
+And there's also a `docker-compose.override.yml` with overrides for development, for example to mount the source code as a volume. It is used automatically by `docker compose` to apply overrides on top of `docker-compose.yml`.
 
 These Docker Compose files use the `.env` file containing configurations to be injected as environment variables in the containers.
 
-They also use some additional configurations taken from environment variables set in the scripts before calling the `docker-compose` command.
+They also use some additional configurations taken from environment variables set in the scripts before calling the `docker compose` command.
 
 It is all designed to support several "stages", like development, building, testing, and deployment. Also, allowing the deployment to different environments like staging and production (and you can add more environments very easily).
 
-They are designed to have the minimum repetition of code and configurations, so that if you need to change something, you have to change it in the minimum amount of places. That's why files use environment variables that get auto-expanded. That way, if for example, you want to use a different domain, you can call the `docker-compose` command with a different `DOMAIN` environment variable instead of having to change the domain in several places inside the Docker Compose files.
+They are designed to have the minimum repetition of code and configurations, so that if you need to change something, you have to change it in the minimum amount of places. That's why files use environment variables that get auto-expanded. That way, if for example, you want to use a different domain, you can call the `docker compose` command with a different `DOMAIN` environment variable instead of having to change the domain in several places inside the Docker Compose files.
 
 Also, if you want to have another deployment environment, say `preprod`, you just have to change environment variables, but you can keep using the same Docker Compose files.
 
@@ -643,8 +641,6 @@ Automatic Interactive Docs (Swagger UI): https://base-project.com/docs
 
 Automatic Alternative Docs (ReDoc): https://base-project.com/redoc
 
-PGAdmin: https://pgadmin.base-project.com
-
 Flower: https://flower.base-project.com
 
 ### Staging URLs
@@ -659,8 +655,6 @@ Automatic Interactive Docs (Swagger UI): https://stag.base-project.com/docs
 
 Automatic Alternative Docs (ReDoc): https://stag.base-project.com/redoc
 
-PGAdmin: https://pgadmin.stag.base-project.com
-
 Flower: https://flower.stag.base-project.com
 
 ### Development URLs
@@ -674,8 +668,6 @@ Backend: http://localhost/api/
 Automatic Interactive Docs (Swagger UI): https://localhost/docs
 
 Automatic Alternative Docs (ReDoc): https://localhost/redoc
-
-PGAdmin: http://localhost:5050
 
 Flower: http://localhost:5555
 
@@ -693,8 +685,6 @@ Automatic Interactive Docs (Swagger UI): https://local.dockertoolbox.tiangolo.co
 
 Automatic Alternative Docs (ReDoc): https://local.dockertoolbox.tiangolo.com/redoc
 
-PGAdmin: http://local.dockertoolbox.tiangolo.com:5050
-
 Flower: http://local.dockertoolbox.tiangolo.com:5555
 
 Traefik UI: http://local.dockertoolbox.tiangolo.com:8090
@@ -710,8 +700,6 @@ Backend: http://dev.base-project.com/api/
 Automatic Interactive Docs (Swagger UI): https://dev.base-project.com/docs
 
 Automatic Alternative Docs (ReDoc): https://dev.base-project.com/redoc
-
-PGAdmin: http://dev.base-project.com:5050
 
 Flower: http://dev.base-project.com:5555
 
@@ -729,15 +717,13 @@ Automatic Interactive Docs (Swagger UI): https://localhost.tiangolo.com/docs
 
 Automatic Alternative Docs (ReDoc): https://localhost.tiangolo.com/redoc
 
-PGAdmin: http://localhost.tiangolo.com:5050
-
 Flower: http://localhost.tiangolo.com:5555
 
 Traefik UI: http://localhost.tiangolo.com:8090
 
 ## Project generation and updating, or re-generating
 
-This project was generated using https://github.com/tiangolo/full-stack-fastapi-postgresql with:
+This project was generated using https://github.com/mongodb-labs/full-stack-fastapi-mongodb with:
 
 ```bash
 pip install cookiecutter
@@ -748,7 +734,7 @@ You can check the variables used during generation in the file `cookiecutter-con
 
 You can generate the project again with the same configurations used the first time.
 
-That would be useful if, for example, the project generator (`tiangolo/full-stack-fastapi-postgresql`) was updated and you wanted to integrate or review the changes.
+That would be useful if, for example, the project generator (`mongodb-labs/full-stack-fastapi-mongodb`) was updated and you wanted to integrate or review the changes.
 
 You could generate a new project with the same configurations as this one in a parallel directory. And compare the differences between the two, without having to overwrite your current code but being able to use the same variables used for your current project.
 
@@ -759,7 +745,7 @@ You can use that file while generating a new project to reuse all those variable
 For example, run:
 
 ```console
-$ cookiecutter --config-file ./cookiecutter-config-file.yml --output-dir ../project-copy https://github.com/tiangolo/full-stack-fastapi-postgresql
+$ cookiecutter --config-file ./cookiecutter-config-file.yml --output-dir ../project-copy https://github.com/mongodb-labs/full-stack-fastapi-mongodb
 ```
 
 That will use the file `cookiecutter-config-file.yml` in the current directory (in this project) to generate a new project inside a sibling directory `project-copy`.

--- a/{{cookiecutter.project_slug}}/backend/app/app/core/security.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/core/security.py
@@ -44,7 +44,7 @@ def create_refresh_token(*, subject: Union[str, Any], expires_delta: timedelta =
         expire = datetime.utcnow() + expires_delta
     else:
         expire = datetime.utcnow() + timedelta(seconds=settings.REFRESH_TOKEN_EXPIRE_SECONDS)
-    to_encode = {"exp": expire, "sub": str(subject), "refresh": True}
+    to_encode = {"exp": expire, "sub": str(subject), "refresh": True, "jti": str(uuid.uuid4())}
     encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.JWT_ALGO)
     return encoded_jwt
 

--- a/{{cookiecutter.project_slug}}/backend/app/app/tests/conftest.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/tests/conftest.py
@@ -18,13 +18,8 @@ settings.MONGO_DATABASE = TEST_DATABASE
 
 
 @pytest.fixture(scope="session")
-def event_loop():
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
+def event_loop_policy():
+    return asyncio.DefaultEventLoopPolicy()
 
 
 @pytest_asyncio.fixture(scope="session")
@@ -46,6 +41,6 @@ def superuser_token_headers(client: TestClient) -> Dict[str, str]:
     return get_superuser_token_headers(client)
 
 
-@pytest_asyncio.fixture(scope="module")
+@pytest_asyncio.fixture(scope="session")
 async def normal_user_token_headers(client: TestClient, db: AgnosticDatabase) -> Dict[str, str]:
     return await authentication_token_from_email(client=client, email=settings.EMAIL_TEST_USER, db=db)

--- a/{{cookiecutter.project_slug}}/backend/app/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/backend/app/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "python-jose[cryptography]>=3.3.0",
   "pydantic>=2.0,<2.7",
   "pydantic-settings>=2.0.3",
-  "httpx>=0.23.1",
+  "httpx>=0.21.0,<0.23.0",
   "psycopg2-binary>=2.9.5",
   "setuptools>=65.6.3",
   "motor>=3.3.1",
@@ -111,6 +111,9 @@ include_trailing_comma = true
 force_grid_wrap = 0
 line_length = 120
 src_paths = ["app", "tests"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
 
 [tool.mypy]
 files = ["**/*.py"]

--- a/{{cookiecutter.project_slug}}/backend/backend.dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/backend.dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/br3ndonland/inboard:fastapi-0.51-python3.11
 COPY ./app/ /app/
 WORKDIR /app/
 ENV HATCH_ENV_TYPE_VIRTUAL_PATH=.venv
-RUN hatch env prune && hatch env create production && pip install --upgrade setuptools
+RUN hatch env prune && hatch env create production && pip install --upgrade setuptools && .venv/bin/pip install --upgrade setuptools "gunicorn>=22.0.0"
 
 # /start Project-specific dependencies
 # RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/{{cookiecutter.project_slug}}/docker-compose.override.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.override.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   proxy:
     ports:

--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   proxy:
     image: traefik:v2.2
@@ -77,13 +76,15 @@ services:
       - ./conf/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
 
   flower:
-    image: mher/flower:0.9.7
+    image: mher/flower:2.0.1
     networks:
       - ${TRAEFIK_PUBLIC_NETWORK?Variable not set}
       - default
     env_file:
       - .env
     command:
+      - celery
+      - flower
       - "--broker=amqp://guest@queue:5672//"
       # For the "Broker" tab to work in the flower UI, uncomment the following command argument,
       # and change the queue service's image as well

--- a/{{cookiecutter.project_slug}}/frontend/.dockerignore
+++ b/{{cookiecutter.project_slug}}/frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/{{cookiecutter.project_slug}}/frontend/.eslintrc.json
+++ b/{{cookiecutter.project_slug}}/frontend/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": ["next", "next/core-web-vitals", "prettier"],
-  "rules": {
-    "@next/next/no-img-element": "off"
-  }
-}

--- a/{{cookiecutter.project_slug}}/frontend/app/assets/css/main.css
+++ b/{{cookiecutter.project_slug}}/frontend/app/assets/css/main.css
@@ -1,4 +1,3 @@
-@import "tailwindcss";
 @tailwind base;
 
 html,

--- a/{{cookiecutter.project_slug}}/frontend/app/declarations.d.ts
+++ b/{{cookiecutter.project_slug}}/frontend/app/declarations.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/{{cookiecutter.project_slug}}/frontend/eslint.config.mjs
+++ b/{{cookiecutter.project_slug}}/frontend/eslint.config.mjs
@@ -1,0 +1,17 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+export default [
+  ...compat.extends("next/core-web-vitals", "prettier"),
+  {
+    rules: {
+      "@next/next/no-img-element": "off",
+    },
+  },
+];

--- a/{{cookiecutter.project_slug}}/frontend/package.json
+++ b/{{cookiecutter.project_slug}}/frontend/package.json
@@ -18,9 +18,10 @@
     "@reduxjs/toolkit": "^1.9.6",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.6",
-    "@tailwindcss/postcss": "^4.0.9",
     "@tailwindcss/typography": "^0.5.10",
+    "autoprefixer": "^10.4.0",
     "gray-matter": "^4.0.3",
+    "postcss": "^8.4.0",
     "next": "^14.0.4",
     "prettier": "^3.1.1",
     "qrcode.react": "^3.1.0",
@@ -34,19 +35,18 @@
     "remark-gfm": "^4.0.0",
     "remark-html": "^16.0.1",
     "remark-toc": "^9.0.0",
+    "tailwindcss": "^3.4.0",
     "webpack": "latest"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "latest",
     "@types/mdx": "^2.0.8",
     "@types/node": "latest",
     "@types/react": "latest",
     "@types/react-dom": "latest",
-    "autoprefixer": "latest",
     "eslint": "latest",
     "eslint-config-next": "latest",
-    "eslint-config-prettier": "^9.1.0",
-    "postcss": "latest",
-    "tailwindcss": "latest",
+    "eslint-config-prettier": "latest",
     "typescript": "latest"
   }
 }

--- a/{{cookiecutter.project_slug}}/frontend/postcss.config.mjs
+++ b/{{cookiecutter.project_slug}}/frontend/postcss.config.mjs
@@ -1,6 +1,6 @@
 const config = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 

--- a/{{cookiecutter.project_slug}}/frontend/tsconfig.json
+++ b/{{cookiecutter.project_slug}}/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/{{cookiecutter.project_slug}}/scripts/build-push.sh
+++ b/{{cookiecutter.project_slug}}/scripts/build-push.sh
@@ -7,4 +7,4 @@ TAG=${TAG?Variable not set} \
 FRONTEND_ENV=${FRONTEND_ENV-production} \
 sh ./scripts/build.sh
 
-docker-compose -f docker-compose.yml push
+docker compose -f docker-compose.yml push

--- a/{{cookiecutter.project_slug}}/scripts/build.sh
+++ b/{{cookiecutter.project_slug}}/scripts/build.sh
@@ -5,6 +5,6 @@ set -e
 
 TAG=${TAG?Variable not set} \
 FRONTEND_ENV=${FRONTEND_ENV-production} \
-docker-compose \
+docker compose \
 -f docker-compose.yml \
 build

--- a/{{cookiecutter.project_slug}}/scripts/deploy.sh
+++ b/{{cookiecutter.project_slug}}/scripts/deploy.sh
@@ -7,9 +7,12 @@ DOMAIN=${DOMAIN?Variable not set} \
 TRAEFIK_TAG=${TRAEFIK_TAG?Variable not set} \
 STACK_NAME=${STACK_NAME?Variable not set} \
 TAG=${TAG?Variable not set} \
-docker-compose \
+docker compose \
 -f docker-compose.yml \
-config > docker-stack.yml
+config \
+| sed '/^name:/d' \
+| sed 's/published: "\([0-9]*\)"/published: \1/g' \
+> docker-stack.yml
 
 docker-auto-labels docker-stack.yml
 

--- a/{{cookiecutter.project_slug}}/scripts/test-local.sh
+++ b/{{cookiecutter.project_slug}}/scripts/test-local.sh
@@ -3,13 +3,13 @@
 # Exit in case of error
 set -e
 
-docker-compose down -v --remove-orphans # Remove possibly previous broken stacks left hanging after an error
+docker compose down -v --remove-orphans # Remove possibly previous broken stacks left hanging after an error
 
 if [ $(uname -s) = "Linux" ]; then
     echo "Remove __pycache__ files"
     sudo find . -type d -name __pycache__ -exec rm -r {} \+
 fi
 
-docker-compose build
-docker-compose up -d
-docker-compose exec -T backend bash /app/tests-start.sh "$@"
+docker compose build
+docker compose up -d
+docker compose exec -T backend bash /app/tests-start.sh "$@"

--- a/{{cookiecutter.project_slug}}/scripts/test.sh
+++ b/{{cookiecutter.project_slug}}/scripts/test.sh
@@ -8,12 +8,12 @@ SMTP_HOST="" \
 TRAEFIK_PUBLIC_NETWORK_IS_EXTERNAL=false \
 TRAEFIK_PUBLIC_NETWORK=traefik-public \
 INSTALL_DEV=true \
-docker-compose \
+docker compose \
 -f docker-compose.yml \
 config > docker-stack.yml
 
-docker-compose -f docker-stack.yml build
-docker-compose -f docker-stack.yml down -v --remove-orphans # Remove possibly previous broken stacks left hanging after an error
-docker-compose -f docker-stack.yml up -d
-docker-compose -f docker-stack.yml exec -T backend bash /app/tests-start.sh "$@"
-docker-compose -f docker-stack.yml down -v --remove-orphans
+docker compose -f docker-stack.yml build
+docker compose -f docker-stack.yml down -v --remove-orphans # Remove possibly previous broken stacks left hanging after an error
+docker compose -f docker-stack.yml up -d
+docker compose -f docker-stack.yml exec -T backend bash /app/tests-start.sh "$@"
+docker compose -f docker-stack.yml down -v --remove-orphans


### PR DESCRIPTION
[INTPYTHON-956](https://jira.mongodb.org/browse/INTPYTHON-956)

This PR addresses bugs identified in #70 and updates the documentation, including removing non-applicable information. Deployment was verified locally to be successful with these changes.

Deployment fixes
  - `docker-compose` → `docker compose` 
  - `deploy.sh`: strip `name: field` and unquote port integers, fixing docker stack deploy validation errors
  - `docker-compose.yml`: removed obsolete `version: "3.3"`; updated flower to `mher/flower:2.0.1`
  - `backend.dockerfile`: `install gunicorn>=22` directly into Hatch `.venv`, fixing pkg_resources missing error
  - `conf/rabbitmq.conf`: created missing file, fixing bind mount error
  - `test/.env`: updated email addresses to valid TLDs for Pydantic validation

Documentation fixes
  - Stale tool references: yarn → npm and Poetry → Hatch
  - Stale framework references: Vue/Nuxt → React/Next.js
  - Stale content: removed PGAdmin URLs (not in this stack); corrected references from `tiangolo/full-stack-fastapi-postgresql` to `mongodb-labs/full-stack-fastapi-mongodb`