### PR TITLE
INTPYTHON-806: Migrate from Motor to PyMongo Async API

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ This FastAPI, React, MongoDB repo will generate a complete web application stack
 - **Docker Compose** integration and optimization for local development.
 - **Authentication** user management schemas, models, crud and apis already built, with OAuth2 JWT token support & default hashing. Offers _magic link_ authentication, with password fallback, with cookie management, including `access` and `refresh` tokens.
 - [**FastAPI**](https://github.com/tiangolo/fastapi) backend with [Inboard](https://inboard.bws.bio/) one-repo Docker images:
-  - **MongoDB Motor** https://motor.readthedocs.io/en/stable/
-  - **MongoDB ODMantic** for handling ODM creation https://art049.github.io/odmantic/
+  - **PyMongo** https://pymongo.readthedocs.io/en/stable/
   - **Common CRUD** support via generic inheritance.
   - **Standards-based**: Based on (and fully compatible with) the open standards for APIs: [OpenAPI](https://github.com/OAI/OpenAPI-Specification) and [JSON Schema](http://json-schema.org/).
   - [**Many other features**]("https://fastapi.tiangolo.com/features/"): including automatic validation, serialization, interactive documentation, etc.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,8 +26,7 @@ This FastAPI, React, MongoDB repo will generate a complete web application stack
 - **Docker Compose** integration and optimization for local development.
 - **Authentication** user management schemas, models, crud and apis already built, with OAuth2 JWT token support & default hashing. Offers _magic link_ authentication, with password fallback, with cookie management, including `access` and `refresh` tokens.
 - [**FastAPI**](https://github.com/tiangolo/fastapi) backend with [Inboard](https://inboard.bws.bio/) one-repo Docker images:
-  - **Mongo Motor** https://motor.readthedocs.io/en/stable/
-  - **MongoDB ODMantic** for handling ODM creation https://art049.github.io/odmantic/
+  - **PyMongo** https://pymongo.readthedocs.io/en/stable/
   - **Common CRUD** support via generic inheritance.
   - **Standards-based**: Based on (and fully compatible with) the open standards for APIs: [OpenAPI](https://github.com/OAI/OpenAPI-Specification) and [JSON Schema](http://json-schema.org/).
   - [**Many other features**]("https://fastapi.tiangolo.com/features/"): including automatic validation, serialization, interactive documentation, etc.

--- a/{{cookiecutter.project_slug}}/backend/app/app/api/api_v1/endpoints/login.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/api/api_v1/endpoints/login.py
@@ -4,7 +4,7 @@ from bson import ObjectId
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi.security import OAuth2PasswordRequestForm
-from motor.core import AgnosticDatabase
+from pymongo.asynchronous.database import AsyncDatabase
 
 from app import crud, models, schemas
 from app.api import deps
@@ -37,7 +37,7 @@ See `security.py` for other requirements.
 
 
 @router.post("/magic/{email}", response_model=schemas.WebToken)
-async def login_with_magic_link(*, db: AgnosticDatabase = Depends(deps.get_db), email: str) -> Any:
+async def login_with_magic_link(*, db: AsyncDatabase = Depends(deps.get_db), email: str) -> Any:
     """
     First step of a 'magic link' login. Check if the user exists and generate a magic link. Generates two short-duration
     jwt tokens, one for validation, one for email. Creates user if not exist.
@@ -59,7 +59,7 @@ async def login_with_magic_link(*, db: AgnosticDatabase = Depends(deps.get_db), 
 @router.post("/claim", response_model=schemas.Token)
 async def validate_magic_link(
     *,
-    db: AgnosticDatabase = Depends(deps.get_db),
+    db: AsyncDatabase = Depends(deps.get_db),
     obj_in: schemas.WebToken,
     magic_in: bool = Depends(deps.get_magic_token),
 ) -> Any:
@@ -97,7 +97,7 @@ async def validate_magic_link(
 
 @router.post("/oauth", response_model=schemas.Token)
 async def login_with_oauth2(
-    db: AgnosticDatabase = Depends(deps.get_db), form_data: OAuth2PasswordRequestForm = Depends()
+    db: AsyncDatabase = Depends(deps.get_db), form_data: OAuth2PasswordRequestForm = Depends()
 ) -> Any:
     """
     First step with OAuth2 compatible token login, get an access token for future requests.
@@ -123,7 +123,7 @@ async def login_with_oauth2(
 @router.post("/totp", response_model=schemas.Token)
 async def login_with_totp(
     *,
-    db: AgnosticDatabase = Depends(deps.get_db),
+    db: AsyncDatabase = Depends(deps.get_db),
     totp_data: schemas.WebToken,
     current_user: models.User = Depends(deps.get_totp_user),
 ) -> Any:
@@ -149,7 +149,7 @@ async def login_with_totp(
 @router.put("/totp", response_model=schemas.Msg)
 async def enable_totp_authentication(
     *,
-    db: AgnosticDatabase = Depends(deps.get_db),
+    db: AsyncDatabase = Depends(deps.get_db),
     data_in: schemas.EnableTOTP,
     current_user: models.User = Depends(deps.get_current_active_user),
 ) -> Any:
@@ -175,7 +175,7 @@ async def enable_totp_authentication(
 @router.delete("/totp", response_model=schemas.Msg)
 async def disable_totp_authentication(
     *,
-    db: AgnosticDatabase = Depends(deps.get_db),
+    db: AsyncDatabase = Depends(deps.get_db),
     data_in: schemas.UserUpdate,
     current_user: models.User = Depends(deps.get_current_active_user),
 ) -> Any:
@@ -192,7 +192,7 @@ async def disable_totp_authentication(
 
 @router.post("/refresh", response_model=schemas.Token)
 async def refresh_token(
-    db: AgnosticDatabase = Depends(deps.get_db),
+    db: AsyncDatabase = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_refresh_user),
 ) -> Any:
     """
@@ -209,7 +209,7 @@ async def refresh_token(
 
 @router.post("/revoke", response_model=schemas.Msg)
 async def revoke_token(
-    db: AgnosticDatabase = Depends(deps.get_db),
+    db: AsyncDatabase = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_refresh_user),
 ) -> Any:
     """
@@ -219,7 +219,7 @@ async def revoke_token(
 
 
 @router.post("/recover/{email}", response_model=Union[schemas.WebToken, schemas.Msg])
-async def recover_password(email: str, db: AgnosticDatabase = Depends(deps.get_db)) -> Any:
+async def recover_password(email: str, db: AsyncDatabase = Depends(deps.get_db)) -> Any:
     """
     Password Recovery
     """
@@ -235,7 +235,7 @@ async def recover_password(email: str, db: AgnosticDatabase = Depends(deps.get_d
 @router.post("/reset", response_model=schemas.Msg)
 async def reset_password(
     *,
-    db: AgnosticDatabase = Depends(deps.get_db),
+    db: AsyncDatabase = Depends(deps.get_db),
     new_password: str = Body(...),
     claim: str = Body(...),
     magic_in: bool = Depends(deps.get_magic_token),

--- a/{{cookiecutter.project_slug}}/backend/app/app/api/api_v1/endpoints/users.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/api/api_v1/endpoints/users.py
@@ -3,7 +3,7 @@ from typing import Any, List
 from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi.encoders import jsonable_encoder
 from pydantic.networks import EmailStr
-from motor.core import AgnosticDatabase
+from pymongo.asynchronous.database import AsyncDatabase
 
 from app import crud, models, schemas
 from app.api import deps
@@ -19,7 +19,7 @@ router = APIRouter()
 @router.post("/", response_model=schemas.User)
 async def create_user_profile(
     *,
-    db: AgnosticDatabase = Depends(deps.get_db),
+    db: AsyncDatabase = Depends(deps.get_db),
     password: str = Body(...),
     email: EmailStr = Body(...),
     full_name: str = Body(""),
@@ -42,7 +42,7 @@ async def create_user_profile(
 @router.put("/", response_model=schemas.User)
 async def update_user(
     *,
-    db: AgnosticDatabase = Depends(deps.get_db),
+    db: AsyncDatabase = Depends(deps.get_db),
     obj_in: schemas.UserUpdate,
     current_user: models.User = Depends(deps.get_current_active_user),
 ) -> Any:
@@ -85,7 +85,7 @@ async def read_user(
 @router.get("/all", response_model=List[schemas.User])
 async def read_all_users(
     *,
-    db: AgnosticDatabase = Depends(deps.get_db),
+    db: AsyncDatabase = Depends(deps.get_db),
     page: int = 0,
     current_user: models.User = Depends(deps.get_current_active_superuser),
 ) -> Any:
@@ -112,7 +112,7 @@ async def request_new_totp(
 @router.post("/toggle-state", response_model=schemas.Msg)
 async def toggle_state(
     *,
-    db: AgnosticDatabase = Depends(deps.get_db),
+    db: AsyncDatabase = Depends(deps.get_db),
     user_in: schemas.UserUpdate,
     current_user: models.User = Depends(deps.get_current_active_superuser),
 ) -> Any:
@@ -131,7 +131,7 @@ async def toggle_state(
 @router.post("/create", response_model=schemas.User)
 async def create_user(
     *,
-    db: AgnosticDatabase = Depends(deps.get_db),
+    db: AsyncDatabase = Depends(deps.get_db),
     user_in: schemas.UserCreate,
     current_user: models.User = Depends(deps.get_current_active_superuser),
 ) -> Any:

--- a/{{cookiecutter.project_slug}}/backend/app/app/api/deps.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/api/deps.py
@@ -4,7 +4,7 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import jwt
 from pydantic import ValidationError
-from motor.core import AgnosticDatabase
+from pymongo.asynchronous.database import AsyncDatabase
 
 from app import crud, models, schemas
 from app.core.config import settings
@@ -34,7 +34,7 @@ def get_token_payload(token: str) -> schemas.TokenPayload:
 
 
 async def get_current_user(
-    db: AgnosticDatabase = Depends(get_db), token: str = Depends(reusable_oauth2)
+    db: AsyncDatabase = Depends(get_db), token: str = Depends(reusable_oauth2)
 ) -> models.User:
     token_data = get_token_payload(token)
     if token_data.refresh or token_data.totp:
@@ -49,7 +49,7 @@ async def get_current_user(
     return user
 
 
-async def get_totp_user(db: AgnosticDatabase = Depends(get_db), token: str = Depends(reusable_oauth2)) -> models.User:
+async def get_totp_user(db: AsyncDatabase = Depends(get_db), token: str = Depends(reusable_oauth2)) -> models.User:
     token_data = get_token_payload(token)
     if token_data.refresh or not token_data.totp:
         # Refresh token is not a valid access token and TOTP False cannot be used to validate TOTP
@@ -76,7 +76,7 @@ def get_magic_token(token: str = Depends(reusable_oauth2)) -> schemas.MagicToken
 
 
 async def get_refresh_user(
-    db: AgnosticDatabase = Depends(get_db), token: str = Depends(reusable_oauth2)
+    db: AsyncDatabase = Depends(get_db), token: str = Depends(reusable_oauth2)
 ) -> models.User:
     token_data = get_token_payload(token)
     if not token_data.refresh:
@@ -91,7 +91,7 @@ async def get_refresh_user(
     if not crud.user.is_active(user):
         raise HTTPException(status_code=400, detail="Inactive user")
     # Check and revoke this refresh token
-    token_obj = await crud.token.get(token=token, user=user)
+    token_obj = await crud.token.get(db, token=token, user=user)
     if not token_obj:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -100,7 +100,7 @@ async def get_refresh_user(
     await crud.token.remove(db, db_obj=token_obj)
 
     # Make sure to revoke all other refresh tokens
-    return await crud.user.get(id=token_data.sub)
+    return await crud.user.get(db, id=token_data.sub)
 
 
 async def get_current_active_user(
@@ -119,7 +119,7 @@ async def get_current_active_superuser(
     return current_user
 
 
-async def get_active_websocket_user(*, db: AgnosticDatabase, token: str) -> models.User:
+async def get_active_websocket_user(*, db: AsyncDatabase, token: str) -> models.User:
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.JWT_ALGO])
         token_data = schemas.TokenPayload(**payload)

--- a/{{cookiecutter.project_slug}}/backend/app/app/core/security.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/core/security.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any, Union
 
 from jose import jwt
@@ -31,9 +31,9 @@ totp_factory = TOTP.using(secrets={"1": settings.TOTP_SECRET_KEY}, issuer=settin
 
 def create_access_token(*, subject: Union[str, Any], expires_delta: timedelta = None, force_totp: bool = False) -> str:
     if expires_delta:
-        expire = datetime.utcnow() + expires_delta
+        expire = datetime.now(UTC) + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(seconds=settings.ACCESS_TOKEN_EXPIRE_SECONDS)
+        expire = datetime.now(UTC) + timedelta(seconds=settings.ACCESS_TOKEN_EXPIRE_SECONDS)
     to_encode = {"exp": expire, "sub": str(subject), "totp": force_totp}
     encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.JWT_ALGO)
     return encoded_jwt
@@ -41,9 +41,9 @@ def create_access_token(*, subject: Union[str, Any], expires_delta: timedelta = 
 
 def create_refresh_token(*, subject: Union[str, Any], expires_delta: timedelta = None) -> str:
     if expires_delta:
-        expire = datetime.utcnow() + expires_delta
+        expire = datetime.now(UTC) + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(seconds=settings.REFRESH_TOKEN_EXPIRE_SECONDS)
+        expire = datetime.now(UTC) + timedelta(seconds=settings.REFRESH_TOKEN_EXPIRE_SECONDS)
     to_encode = {"exp": expire, "sub": str(subject), "refresh": True, "jti": str(uuid.uuid4())}
     encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.JWT_ALGO)
     return encoded_jwt
@@ -51,9 +51,9 @@ def create_refresh_token(*, subject: Union[str, Any], expires_delta: timedelta =
 
 def create_magic_tokens(*, subject: Union[str, Any], expires_delta: timedelta = None) -> list[str]:
     if expires_delta:
-        expire = datetime.utcnow() + expires_delta
+        expire = datetime.now(UTC) + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(seconds=settings.ACCESS_TOKEN_EXPIRE_SECONDS)
+        expire = datetime.now(UTC) + timedelta(seconds=settings.ACCESS_TOKEN_EXPIRE_SECONDS)
     fingerprint = str(uuid.uuid4())
     magic_tokens = []
     # First sub is the user.id, to be emailed. Second is the disposable id.

--- a/{{cookiecutter.project_slug}}/backend/app/app/crud/base.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/crud/base.py
@@ -13,6 +13,14 @@ UpdateSchemaType = TypeVar("UpdateSchemaType", bound=BaseModel)
 
 class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
     def __init__(self, model: Type[ModelType]):
+        """
+        CRUD object with default methods to Create, Read, Update, Delete (CRUD).
+
+        **Parameters**
+
+        * `model`: A SQLAlchemy model class
+        * `schema`: A Pydantic model (schema) class
+        """
         self.model = model
 
     def _collection(self, db: AsyncDatabase):

--- a/{{cookiecutter.project_slug}}/backend/app/app/crud/base.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/crud/base.py
@@ -1,13 +1,10 @@
 from typing import Any, Dict, Generic, Type, TypeVar, Union
 
-from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
-from motor.core import AgnosticDatabase
-from odmantic import AIOEngine
+from pymongo.asynchronous.database import AsyncDatabase
 
 from app.db.base_class import Base
 from app.core.config import settings
-from app.db.session import get_engine
 
 ModelType = TypeVar("ModelType", bound=Base)
 CreateSchemaType = TypeVar("CreateSchemaType", bound=BaseModel)
@@ -16,46 +13,49 @@ UpdateSchemaType = TypeVar("UpdateSchemaType", bound=BaseModel)
 
 class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
     def __init__(self, model: Type[ModelType]):
-        """
-        CRUD object with default methods to Create, Read, Update, Delete (CRUD).
-
-        **Parameters**
-
-        * `model`: A SQLAlchemy model class
-        * `schema`: A Pydantic model (schema) class
-        """
         self.model = model
-        self.engine: AIOEngine = get_engine()
 
-    async def get(self, db: AgnosticDatabase, id: Any) -> ModelType | None:
-        return await self.engine.find_one(self.model, self.model.id == id)
+    def _collection(self, db: AsyncDatabase):
+        return db[self.model.__collection__]
 
-    async def get_multi(self, db: AgnosticDatabase, *, page: int = 0, page_break: bool = False) -> list[ModelType]: # noqa
-        offset = {"skip": page * settings.MULTI_MAX, "limit": settings.MULTI_MAX} if page_break else {} # noqa
-        return await self.engine.find(self.model, **offset)
+    def _from_mongo(self, doc: dict) -> ModelType:
+        return self.model.model_validate(doc)
 
-    async def create(self, db: AgnosticDatabase, *, obj_in: CreateSchemaType) -> ModelType: # noqa
-        obj_in_data = jsonable_encoder(obj_in)
-        db_obj = self.model(**obj_in_data)  # type: ignore
-        return await self.engine.save(db_obj)
+    def _to_mongo(self, obj: ModelType) -> dict:
+        return obj.to_mongo()
+
+    async def get(self, db: AsyncDatabase, id: Any) -> ModelType | None:
+        doc = await self._collection(db).find_one({"_id": id})
+        return self._from_mongo(doc) if doc else None
+
+    async def get_multi(self, db: AsyncDatabase, *, page: int = 0, page_break: bool = False) -> list[ModelType]: # noqa
+        if page_break:
+            cursor = self._collection(db).find({}, skip=page * settings.MULTI_MAX, limit=settings.MULTI_MAX)
+        else:
+            cursor = self._collection(db).find({})
+        return [self._from_mongo(doc) async for doc in cursor]
+
+    async def create(self, db: AsyncDatabase, *, obj_in: CreateSchemaType) -> ModelType: # noqa
+        db_obj = self.model(**obj_in.model_dump())
+        await self._collection(db).insert_one(self._to_mongo(db_obj))
+        return db_obj
 
     async def update(
-        self, db: AgnosticDatabase, *, db_obj: ModelType, obj_in: Union[UpdateSchemaType, Dict[str, Any]] # noqa
+        self, db: AsyncDatabase, *, db_obj: ModelType, obj_in: Union[UpdateSchemaType, Dict[str, Any]] # noqa
     ) -> ModelType:
-        obj_data = jsonable_encoder(db_obj)
         if isinstance(obj_in, dict):
             update_data = obj_in
         else:
             update_data = obj_in.model_dump(exclude_unset=True)
-        for field in obj_data:
+        for field in db_obj.model_dump():
             if field in update_data:
                 setattr(db_obj, field, update_data[field])
         # TODO: Check if this saves changes with the setattr calls
-        await self.engine.save(db_obj)
+        await self._collection(db).replace_one({"_id": db_obj.id}, self._to_mongo(db_obj))
         return db_obj
 
-    async def remove(self, db: AgnosticDatabase, *, id: int) -> ModelType:
-        obj = await self.model.get(id)
+    async def remove(self, db: AsyncDatabase, *, id: Any) -> ModelType | None:
+        obj = await self.get(db, id=id)
         if obj:
-            await self.engine.delete(obj)
+            await self._collection(db).delete_one({"_id": id})
         return obj

--- a/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_token.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_token.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from motor.core import AgnosticDatabase
+from pymongo.asynchronous.database import AsyncDatabase
 
 from app.crud.base import CRUDBase
 from app.models import User, Token
@@ -9,32 +9,39 @@ from app.core.config import settings
 
 class CRUDToken(CRUDBase[Token, RefreshTokenCreate, RefreshTokenUpdate]):
     # Everything is user-dependent
-    async def create(self, db: AgnosticDatabase, *, obj_in: str, user_obj: User) -> Token:
-        db_obj = await self.engine.find_one(self.model, self.model.token == obj_in)
-        if db_obj:
+    async def create(self, db: AsyncDatabase, *, obj_in: str, user_obj: User) -> Token:
+        doc = await self._collection(db).find_one({"token": obj_in})
+        if doc:
+            db_obj = self._from_mongo(doc)
             if db_obj.authenticates_id != user_obj.id:
                 raise ValueError("Token mismatch between key and user.")
             return db_obj
         else:
-            new_token = self.model(token=obj_in, authenticates_id=user_obj)
+            new_token = self.model(token=obj_in, authenticates_id=user_obj.id)
             user_obj.refresh_tokens.append(new_token.id)
-            await self.engine.save_all([new_token, user_obj])
+            await self._collection(db).insert_one(self._to_mongo(new_token))
+            await db[User.__collection__].replace_one({"_id": user_obj.id}, user_obj.to_mongo())
             return new_token
 
-    async def get(self, *, user: User, token: str) -> Token:
-        return await self.engine.find_one(User, ((User.id == user.id) & (User.refresh_tokens == token)))
+    async def get(self, db: AsyncDatabase, *, user: User, token: str) -> Token | None:
+        doc = await self._collection(db).find_one({"token": token, "authenticates_id": user.id})
+        return self._from_mongo(doc) if doc else None
 
-    async def get_multi(self, *, user: User, page: int = 0, page_break: bool = False) -> list[Token]:
-        offset = {"skip": page * settings.MULTI_MAX, "limit": settings.MULTI_MAX} if page_break else {}
-        return await self.engine.find(User, (User.refresh_tokens.in_([user.refresh_tokens])), **offset)
+    async def get_multi(self, db: AsyncDatabase, *, user: User, page: int = 0, page_break: bool = False) -> list[Token]:
+        filter_q = {"authenticates_id": user.id}
+        if page_break:
+            cursor = self._collection(db).find(filter_q, skip=page * settings.MULTI_MAX, limit=settings.MULTI_MAX)
+        else:
+            cursor = self._collection(db).find(filter_q)
+        return [self._from_mongo(doc) async for doc in cursor]
 
-    async def remove(self, db: AgnosticDatabase, *, db_obj: Token) -> None:
-        users = []
-        async for user in self.engine.find(User, User.refresh_tokens.in_([db_obj.id])):
+    async def remove(self, db: AsyncDatabase, *, db_obj: Token) -> None:
+        user_col = db[User.__collection__]
+        async for doc in user_col.find({"refresh_tokens": db_obj.id}):
+            user = User.model_validate(doc)
             user.refresh_tokens.remove(db_obj.id)
-            users.append(user)
-        await self.engine.save(users)
-        await self.engine.delete(db_obj)
+            await user_col.replace_one({"_id": user.id}, user.to_mongo())
+        await self._collection(db).delete_one({"_id": db_obj.id})
 
 
 token = CRUDToken(Token)

--- a/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_token.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_token.py
@@ -10,9 +10,9 @@ from app.core.config import settings
 class CRUDToken(CRUDBase[Token, RefreshTokenCreate, RefreshTokenUpdate]):
     # Everything is user-dependent
     async def create(self, db: AsyncDatabase, *, obj_in: str, user_obj: User) -> Token:
-        doc = await self._collection(db).find_one({"token": obj_in})
-        if doc:
-            db_obj = self._from_mongo(doc)
+        db_obj = await self._collection(db).find_one({"token": obj_in})
+        if db_obj:
+            db_obj = self._from_mongo(db_obj)
             if db_obj.authenticates_id != user_obj.id:
                 raise ValueError("Token mismatch between key and user.")
             return db_obj
@@ -28,19 +28,14 @@ class CRUDToken(CRUDBase[Token, RefreshTokenCreate, RefreshTokenUpdate]):
         return self._from_mongo(doc) if doc else None
 
     async def get_multi(self, db: AsyncDatabase, *, user: User, page: int = 0, page_break: bool = False) -> list[Token]:
-        filter_q = {"authenticates_id": user.id}
-        if page_break:
-            cursor = self._collection(db).find(filter_q, skip=page * settings.MULTI_MAX, limit=settings.MULTI_MAX)
-        else:
-            cursor = self._collection(db).find(filter_q)
-        return [self._from_mongo(doc) async for doc in cursor]
+        offset = {"skip": page * settings.MULTI_MAX, "limit": settings.MULTI_MAX} if page_break else {}
+        return [self._from_mongo(doc) async for doc in self._collection(db).find({"authenticates_id": user.id}, **offset)]
 
     async def remove(self, db: AsyncDatabase, *, db_obj: Token) -> None:
-        user_col = db[User.__collection__]
-        async for doc in user_col.find({"refresh_tokens": db_obj.id}):
-            user = User.model_validate(doc)
+        async for user in db[User.__collection__].find({"refresh_tokens": db_obj.id}):
+            user = User.model_validate(user)
             user.refresh_tokens.remove(db_obj.id)
-            await user_col.replace_one({"_id": user.id}, user.to_mongo())
+            await db[User.__collection__].replace_one({"_id": user.id}, user.to_mongo())
         await self._collection(db).delete_one({"_id": db_obj.id})
 
 

--- a/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Union
 
-from motor.core import AgnosticDatabase
+from pymongo.asynchronous.database import AsyncDatabase
 
 from app.core.security import get_password_hash, verify_password
 from app.crud.base import CRUDBase
@@ -11,22 +11,24 @@ from app.schemas.totp import NewTOTP
 
 # ODM, Schema, Schema
 class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
-    async def get_by_email(self, db: AgnosticDatabase, *, email: str) -> User | None: # noqa
-        return await self.engine.find_one(User, User.email == email)
+    async def get_by_email(self, db: AsyncDatabase, *, email: str) -> User | None: # noqa
+        doc = await self._collection(db).find_one({"email": email})
+        return self._from_mongo(doc) if doc else None
 
-    async def create(self, db: AgnosticDatabase, *, obj_in: UserCreate) -> User: # noqa
+    async def create(self, db: AsyncDatabase, *, obj_in: UserCreate) -> User: # noqa
         # TODO: Figure out what happens when you have a unique key like 'email'
-        user = {
+        user_data = {
             **obj_in.model_dump(),
             "email": obj_in.email,
             "hashed_password": get_password_hash(obj_in.password) if obj_in.password is not None else None, # noqa
             "full_name": obj_in.full_name,
             "is_superuser": obj_in.is_superuser,
         }
+        db_obj = User(**user_data)
+        await self._collection(db).insert_one(self._to_mongo(db_obj))
+        return db_obj
 
-        return await self.engine.save(User(**user))
-
-    async def update(self, db: AgnosticDatabase, *, db_obj: User, obj_in: Union[UserUpdate, Dict[str, Any]]) -> User: # noqa
+    async def update(self, db: AsyncDatabase, *, db_obj: User, obj_in: Union[UserUpdate, Dict[str, Any]]) -> User: # noqa
         if isinstance(obj_in, dict):
             update_data = obj_in
         else:
@@ -39,7 +41,7 @@ class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
             update_data["email_validated"] = False
         return await super().update(db, db_obj=db_obj, obj_in=update_data)
 
-    async def authenticate(self, db: AgnosticDatabase, *, email: str, password: str) -> User | None: # noqa
+    async def authenticate(self, db: AsyncDatabase, *, email: str, password: str) -> User | None: # noqa
         user = await self.get_by_email(db, email=email)
         if not user:
             return None
@@ -47,31 +49,31 @@ class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
             return None
         return user
 
-    async def validate_email(self, db: AgnosticDatabase, *, db_obj: User) -> User: # noqa
+    async def validate_email(self, db: AsyncDatabase, *, db_obj: User) -> User: # noqa
         obj_in = UserUpdate(**UserInDB.model_validate(db_obj).model_dump())
         obj_in.email_validated = True
         return await self.update(db=db, db_obj=db_obj, obj_in=obj_in)
 
-    async def activate_totp(self, db: AgnosticDatabase, *, db_obj: User, totp_in: NewTOTP) -> User: # noqa
+    async def activate_totp(self, db: AsyncDatabase, *, db_obj: User, totp_in: NewTOTP) -> User: # noqa
         obj_in = UserUpdate(**UserInDB.model_validate(db_obj).model_dump())
         obj_in = obj_in.model_dump(exclude_unset=True)
         obj_in["totp_secret"] = totp_in.secret
         return await self.update(db=db, db_obj=db_obj, obj_in=obj_in)
 
-    async def deactivate_totp(self, db: AgnosticDatabase, *, db_obj: User) -> User: # noqa
+    async def deactivate_totp(self, db: AsyncDatabase, *, db_obj: User) -> User: # noqa
         obj_in = UserUpdate(**UserInDB.model_validate(db_obj).model_dump())
         obj_in = obj_in.model_dump(exclude_unset=True)
         obj_in["totp_secret"] = None
         obj_in["totp_counter"] = None
         return await self.update(db=db, db_obj=db_obj, obj_in=obj_in)
 
-    async def update_totp_counter(self, db: AgnosticDatabase, *, db_obj: User, new_counter: int) -> User:  # noqa
+    async def update_totp_counter(self, db: AsyncDatabase, *, db_obj: User, new_counter: int) -> User:  # noqa
         obj_in = UserUpdate(**UserInDB.model_validate(db_obj).model_dump())
         obj_in = obj_in.model_dump(exclude_unset=True)
         obj_in["totp_counter"] = new_counter
         return await self.update(db=db, db_obj=db_obj, obj_in=obj_in)
 
-    async def toggle_user_state(self, db: AgnosticDatabase, *, obj_in: Union[UserUpdate, Dict[str, Any]]) -> User: # noqa
+    async def toggle_user_state(self, db: AsyncDatabase, *, obj_in: Union[UserUpdate, Dict[str, Any]]) -> User: # noqa
         db_obj = await self.get_by_email(db, email=obj_in.email)
         if not db_obj:
             return None

--- a/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
@@ -17,14 +17,14 @@ class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
 
     async def create(self, db: AsyncDatabase, *, obj_in: UserCreate) -> User: # noqa
         # TODO: Figure out what happens when you have a unique key like 'email'
-        user_data = {
+        user = {
             **obj_in.model_dump(),
             "email": obj_in.email,
             "hashed_password": get_password_hash(obj_in.password) if obj_in.password is not None else None, # noqa
             "full_name": obj_in.full_name,
             "is_superuser": obj_in.is_superuser,
         }
-        db_obj = User(**user_data)
+        db_obj = User(**user)
         await self._collection(db).insert_one(self._to_mongo(db_obj))
         return db_obj
 

--- a/{{cookiecutter.project_slug}}/backend/app/app/db/base_class.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/db/base_class.py
@@ -1,3 +1,42 @@
-from odmantic import Model
+from typing import Annotated, Any
+from bson import ObjectId
+from pydantic import BaseModel, ConfigDict, Field, GetCoreSchemaHandler
+from pydantic_core import core_schema
 
-Base = Model
+
+class _ObjectIdAnnotation:
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        _source_type: Any,
+        _handler: GetCoreSchemaHandler,
+    ) -> core_schema.CoreSchema:
+        def validate(value: Any) -> ObjectId:
+            if isinstance(value, ObjectId):
+                return value
+            if isinstance(value, str) and ObjectId.is_valid(value):
+                return ObjectId(value)
+            raise ValueError(f"Invalid ObjectId: {value!r}")
+
+        return core_schema.no_info_plain_validator_function(
+            validate,
+            serialization=core_schema.to_string_ser_schema(),
+        )
+
+
+PyObjectId = Annotated[ObjectId, _ObjectIdAnnotation]
+
+
+class Base(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+    )
+    id: PyObjectId = Field(default_factory=ObjectId, alias="_id")
+
+    def to_mongo(self) -> dict:
+        return self.model_dump(by_alias=True)
+
+    @classmethod
+    def from_mongo(cls, data: dict) -> "Base":
+        return cls.model_validate(data)

--- a/{{cookiecutter.project_slug}}/backend/app/app/db/session.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/db/session.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from app.core.config import settings
 from app.__version__ import __version__
 from pymongo import AsyncMongoClient
@@ -8,15 +10,21 @@ DRIVER_INFO = DriverInfo(name="full-stack-fastapi-mongodb", version=__version__)
 
 
 class _MongoClientSingleton:
-    mongo_client: AsyncMongoClient | None
+    _instances: dict = {}
 
     def __new__(cls):
-        if not hasattr(cls, "instance"):
-            cls.instance = super(_MongoClientSingleton, cls).__new__(cls)
-            cls.instance.mongo_client = AsyncMongoClient(
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        loop_id = id(loop)
+        if loop_id not in cls._instances:
+            instance = super().__new__(cls)
+            instance.mongo_client = AsyncMongoClient(
                 settings.MONGO_DATABASE_URI, driver=DRIVER_INFO
             )
-        return cls.instance
+            cls._instances[loop_id] = instance
+        return cls._instances[loop_id]
 
 
 def MongoDatabase() -> AsyncDatabase:

--- a/{{cookiecutter.project_slug}}/backend/app/app/db/session.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/db/session.py
@@ -1,32 +1,26 @@
 from app.core.config import settings
 from app.__version__ import __version__
-from motor import motor_asyncio, core
-from odmantic import AIOEngine
+from pymongo import AsyncMongoClient
+from pymongo.asynchronous.database import AsyncDatabase
 from pymongo.driver_info import DriverInfo
 
 DRIVER_INFO = DriverInfo(name="full-stack-fastapi-mongodb", version=__version__)
 
 
 class _MongoClientSingleton:
-    mongo_client: motor_asyncio.AsyncIOMotorClient | None
-    engine: AIOEngine
+    mongo_client: AsyncMongoClient | None
 
     def __new__(cls):
         if not hasattr(cls, "instance"):
             cls.instance = super(_MongoClientSingleton, cls).__new__(cls)
-            cls.instance.mongo_client = motor_asyncio.AsyncIOMotorClient(
+            cls.instance.mongo_client = AsyncMongoClient(
                 settings.MONGO_DATABASE_URI, driver=DRIVER_INFO
             )
-            cls.instance.engine = AIOEngine(client=cls.instance.mongo_client, database=settings.MONGO_DATABASE)
         return cls.instance
 
 
-def MongoDatabase() -> core.AgnosticDatabase:
+def MongoDatabase() -> AsyncDatabase:
     return _MongoClientSingleton().mongo_client[settings.MONGO_DATABASE]
-
-
-def get_engine() -> AIOEngine:
-    return _MongoClientSingleton().engine
 
 
 async def ping():

--- a/{{cookiecutter.project_slug}}/backend/app/app/models/token.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/models/token.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
+from typing import ClassVar
 
-from odmantic import Reference
-
-from app.db.base_class import Base
+from app.db.base_class import Base, PyObjectId
 
 from .user import User  # noqa: F401
 
 
 # Consider reworking to consolidate information to a userId. This may not work well
 class Token(Base):
+    __collection__: ClassVar[str] = "token"
     token: str
-    authenticates_id: User = Reference()
+    authenticates_id: PyObjectId

--- a/{{cookiecutter.project_slug}}/backend/app/app/models/user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/models/user.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 from datetime import datetime
-from pydantic import EmailStr
-from odmantic import ObjectId, Field
+from pydantic import EmailStr, Field
 
-from app.db.base_class import Base
+from app.db.base_class import Base, PyObjectId
 
 if TYPE_CHECKING:
     from . import Token  # noqa: F401
@@ -15,6 +14,8 @@ def datetime_now_sec():
 
 
 class User(Base):
+    __collection__: ClassVar[str] = "user"
+
     created: datetime = Field(default_factory=datetime_now_sec)
     modified: datetime = Field(default_factory=datetime_now_sec)
     full_name: str = Field(default="")
@@ -25,4 +26,4 @@ class User(Base):
     email_validated: bool = Field(default=False)
     is_active: bool = Field(default=False)
     is_superuser: bool = Field(default=False)
-    refresh_tokens: list[ObjectId] = Field(default_factory=list)
+    refresh_tokens: list[PyObjectId] = Field(default_factory=list)

--- a/{{cookiecutter.project_slug}}/backend/app/app/schemas/token.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/schemas/token.py
@@ -1,14 +1,15 @@
 from pydantic import BaseModel, ConfigDict, SecretStr
-from odmantic import Model, ObjectId
+
+from app.db.base_class import PyObjectId
 
 
 class RefreshTokenBase(BaseModel):
     token: SecretStr
-    authenticates: Model | None = None
+    authenticates: BaseModel | None = None
 
 
 class RefreshTokenCreate(RefreshTokenBase):
-    authenticates: Model
+    authenticates: BaseModel
 
 
 class RefreshTokenUpdate(RefreshTokenBase):
@@ -26,14 +27,14 @@ class Token(BaseModel):
 
 
 class TokenPayload(BaseModel):
-    sub: ObjectId | None = None
+    sub: PyObjectId | None = None
     refresh: bool | None = False
     totp: bool | None = False
 
 
 class MagicTokenPayload(BaseModel):
-    sub: ObjectId | None = None
-    fingerprint: ObjectId | None = None
+    sub: PyObjectId | None = None
+    fingerprint: PyObjectId | None = None
 
 
 class WebToken(BaseModel):

--- a/{{cookiecutter.project_slug}}/backend/app/app/schemas/user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/schemas/user.py
@@ -1,6 +1,7 @@
 from typing_extensions import Annotated
 from pydantic import BaseModel, ConfigDict, Field, EmailStr, StringConstraints, field_validator, SecretStr
-from odmantic import ObjectId
+
+from app.db.base_class import PyObjectId
 
 
 class UserLogin(BaseModel):
@@ -30,7 +31,7 @@ class UserUpdate(UserBase):
 
 
 class UserInDBBase(UserBase):
-    id: ObjectId | None = None
+    id: PyObjectId | None = None
     model_config = ConfigDict(from_attributes=True)
 
 

--- a/{{cookiecutter.project_slug}}/backend/app/app/tests/api/api_v1/test_users.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/tests/api/api_v1/test_users.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
 from fastapi.testclient import TestClient
-from motor.core import AgnosticDatabase
+from pymongo.asynchronous.database import AsyncDatabase
 import pytest
 
 from app import crud
@@ -31,7 +31,7 @@ async def test_get_users_normal_user_me(client: TestClient, normal_user_token_he
 
 
 @pytest.mark.asyncio
-async def test_create_user_new_email(client: TestClient, superuser_token_headers: dict, db: AgnosticDatabase) -> None:
+async def test_create_user_new_email(client: TestClient, superuser_token_headers: dict, db: AsyncDatabase) -> None:
     username = random_email()
     password = random_lower_string()
     data = {"email": username, "password": password}
@@ -49,7 +49,7 @@ async def test_create_user_new_email(client: TestClient, superuser_token_headers
 
 @pytest.mark.asyncio
 async def test_create_user_existing_username(
-    client: TestClient, superuser_token_headers: dict, db: AgnosticDatabase
+    client: TestClient, superuser_token_headers: dict, db: AsyncDatabase
 ) -> None:
     username = random_email()
     # username = email
@@ -68,7 +68,7 @@ async def test_create_user_existing_username(
 
 
 @pytest.mark.asyncio
-async def test_retrieve_users(client: TestClient, superuser_token_headers: dict, db: AgnosticDatabase) -> None:
+async def test_retrieve_users(client: TestClient, superuser_token_headers: dict, db: AsyncDatabase) -> None:
     username = random_email()
     password = random_lower_string()
     user_in = UserCreate(email=username, password=password)

--- a/{{cookiecutter.project_slug}}/backend/app/app/tests/conftest.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/tests/conftest.py
@@ -4,12 +4,12 @@ from typing import Dict, Generator
 import pytest
 import pytest_asyncio
 from fastapi.testclient import TestClient
-from motor.core import AgnosticDatabase
+from pymongo.asynchronous.database import AsyncDatabase
 
 from app.core.config import settings
 from app.db.init_db import init_db
 from app.main import app
-from app.db.session import MongoDatabase, _MongoClientSingleton
+from app.db.session import MongoDatabase
 from app.tests.utils.user import authentication_token_from_email
 from app.tests.utils.utils import get_superuser_token_headers
 
@@ -30,7 +30,6 @@ def event_loop():
 @pytest_asyncio.fixture(scope="session")
 async def db() -> Generator:
     db = MongoDatabase()
-    _MongoClientSingleton.instance.mongo_client.get_io_loop = asyncio.get_event_loop
     await init_db(db)
     yield db
 
@@ -47,5 +46,5 @@ def superuser_token_headers(client: TestClient) -> Dict[str, str]:
 
 
 @pytest_asyncio.fixture(scope="module")
-async def normal_user_token_headers(client: TestClient, db: AgnosticDatabase) -> Dict[str, str]:
+async def normal_user_token_headers(client: TestClient, db: AsyncDatabase) -> Dict[str, str]:
     return await authentication_token_from_email(client=client, email=settings.EMAIL_TEST_USER, db=db)

--- a/{{cookiecutter.project_slug}}/backend/app/app/tests/conftest.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/tests/conftest.py
@@ -1,15 +1,16 @@
 import asyncio
-from typing import Dict, Generator
+from typing import AsyncGenerator, Dict, Generator
 
 import pytest
 import pytest_asyncio
 from fastapi.testclient import TestClient
+from pymongo import AsyncMongoClient
 from pymongo.asynchronous.database import AsyncDatabase
 
 from app.core.config import settings
 from app.db.init_db import init_db
 from app.main import app
-from app.db.session import MongoDatabase
+from app.db.session import DRIVER_INFO, MongoDatabase
 from app.tests.utils.user import authentication_token_from_email
 from app.tests.utils.utils import get_superuser_token_headers
 
@@ -22,15 +23,25 @@ def event_loop_policy():
     return asyncio.DefaultEventLoopPolicy()
 
 
-@pytest_asyncio.fixture(scope="session")
-async def db() -> Generator:
+@pytest_asyncio.fixture(scope="session", autouse=True)
+async def _init_db() -> AsyncGenerator:
+    """Seed the test database once per session."""
     db = MongoDatabase()
     await init_db(db)
-    yield db
+    yield
+
+
+@pytest_asyncio.fixture
+async def db() -> AsyncGenerator:
+    """Fresh per-test database handle with its own client to avoid cross-loop issues."""
+    client = AsyncMongoClient(settings.MONGO_DATABASE_URI, driver=DRIVER_INFO)
+    database = client[settings.MONGO_DATABASE]
+    yield database
+    await client.close()
 
 
 @pytest.fixture(scope="session")
-def client(db) -> Generator:
+def client() -> Generator:
     with TestClient(app) as c:
         yield c
 
@@ -40,6 +51,13 @@ def superuser_token_headers(client: TestClient) -> Dict[str, str]:
     return get_superuser_token_headers(client)
 
 
-@pytest_asyncio.fixture(scope="module")
-async def normal_user_token_headers(client: TestClient, db: AsyncDatabase) -> Dict[str, str]:
-    return await authentication_token_from_email(client=client, email=settings.EMAIL_TEST_USER, db=db)
+@pytest_asyncio.fixture
+async def normal_user_token_headers(client: TestClient) -> Dict[str, str]:
+    client_conn = AsyncMongoClient(settings.MONGO_DATABASE_URI, driver=DRIVER_INFO)
+    db = client_conn[settings.MONGO_DATABASE]
+    try:
+        return await authentication_token_from_email(
+            client=client, email=settings.EMAIL_TEST_USER, db=db
+        )
+    finally:
+        await client_conn.close()

--- a/{{cookiecutter.project_slug}}/backend/app/app/tests/crud/test_user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/tests/crud/test_user.py
@@ -1,5 +1,5 @@
 from fastapi.encoders import jsonable_encoder
-from motor.core import AgnosticDatabase
+from pymongo.asynchronous.database import AsyncDatabase
 import pytest
 
 from app import crud
@@ -9,7 +9,7 @@ from app.tests.utils.utils import random_email, random_lower_string
 
 
 @pytest.mark.asyncio
-async def test_create_user(db: AgnosticDatabase) -> None:
+async def test_create_user(db: AsyncDatabase) -> None:
     email = random_email()
     password = random_lower_string()
     user_in = UserCreate(email=email, password=password)
@@ -19,7 +19,7 @@ async def test_create_user(db: AgnosticDatabase) -> None:
 
 
 @pytest.mark.asyncio
-async def test_authenticate_user(db: AgnosticDatabase) -> None:
+async def test_authenticate_user(db: AsyncDatabase) -> None:
     email = random_email()
     password = random_lower_string()
     user_in = UserCreate(email=email, password=password)
@@ -30,7 +30,7 @@ async def test_authenticate_user(db: AgnosticDatabase) -> None:
 
 
 @pytest.mark.asyncio
-async def test_not_authenticate_user(db: AgnosticDatabase) -> None:
+async def test_not_authenticate_user(db: AsyncDatabase) -> None:
     email = random_email()
     password = random_lower_string()
     user = await crud.user.authenticate(db, email=email, password=password)
@@ -38,7 +38,7 @@ async def test_not_authenticate_user(db: AgnosticDatabase) -> None:
 
 
 @pytest.mark.asyncio
-async def test_check_if_user_is_active(db: AgnosticDatabase) -> None:
+async def test_check_if_user_is_active(db: AsyncDatabase) -> None:
     email = random_email()
     password = random_lower_string()
     user_in = UserCreate(email=email, password=password)
@@ -48,7 +48,7 @@ async def test_check_if_user_is_active(db: AgnosticDatabase) -> None:
 
 
 @pytest.mark.asyncio
-async def test_check_if_user_is_active_inactive(db: AgnosticDatabase) -> None:
+async def test_check_if_user_is_active_inactive(db: AsyncDatabase) -> None:
     email = random_email()
     password = random_lower_string()
     user_in = UserCreate(email=email, password=password, disabled=True)
@@ -58,7 +58,7 @@ async def test_check_if_user_is_active_inactive(db: AgnosticDatabase) -> None:
 
 
 @pytest.mark.asyncio
-async def test_check_if_user_is_superuser(db: AgnosticDatabase) -> None:
+async def test_check_if_user_is_superuser(db: AsyncDatabase) -> None:
     email = random_email()
     password = random_lower_string()
     user_in = UserCreate(email=email, password=password, is_superuser=True)
@@ -68,7 +68,7 @@ async def test_check_if_user_is_superuser(db: AgnosticDatabase) -> None:
 
 
 @pytest.mark.asyncio
-async def test_check_if_user_is_superuser_normal_user(db: AgnosticDatabase) -> None:
+async def test_check_if_user_is_superuser_normal_user(db: AsyncDatabase) -> None:
     username = random_email()
     password = random_lower_string()
     user_in = UserCreate(email=username, password=password)
@@ -78,7 +78,7 @@ async def test_check_if_user_is_superuser_normal_user(db: AgnosticDatabase) -> N
 
 
 @pytest.mark.asyncio
-async def test_get_user(db: AgnosticDatabase) -> None:
+async def test_get_user(db: AsyncDatabase) -> None:
     password = random_lower_string()
     username = random_email()
     user_in = UserCreate(email=username, password=password, is_superuser=True)
@@ -90,7 +90,7 @@ async def test_get_user(db: AgnosticDatabase) -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_user(db: AgnosticDatabase) -> None:
+async def test_update_user(db: AsyncDatabase) -> None:
     password = random_lower_string()
     email = random_email()
     user_in = UserCreate(email=email, password=password, is_superuser=True)

--- a/{{cookiecutter.project_slug}}/backend/app/app/tests/utils/user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/tests/utils/user.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
 from fastapi.testclient import TestClient
-from motor.core import AgnosticDatabase
+from pymongo.asynchronous.database import AsyncDatabase
 
 from app import crud
 from app.core.config import settings
@@ -20,7 +20,7 @@ def user_authentication_headers(*, client: TestClient, email: str, password: str
     return headers
 
 
-async def authentication_token_from_email(*, client: TestClient, email: str, db: AgnosticDatabase) -> Dict[str, str]:
+async def authentication_token_from_email(*, client: TestClient, email: str, db: AsyncDatabase) -> Dict[str, str]:
     """
     Return a valid token for the user with given email.
 

--- a/{{cookiecutter.project_slug}}/backend/app/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/backend/app/pyproject.toml
@@ -35,13 +35,12 @@ dependencies = [
   "httpx>=0.23.1",
   "psycopg2-binary>=2.9.5",
   "setuptools>=65.6.3",
-  "motor>=3.3.1",
+  "pymongo>=4.9",
   "pytest==7.4.2",
   "pytest-cov==4.1.0",
   "pytest-asyncio>=0.21.0",
   "argon2-cffi==23.1.0",
   "argon2-cffi-bindings==21.2.0",
-  "odmantic>=1.0,<2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
[INTPYTHON-806](https://jira.mongodb.org/browse/INTPYTHON-806)

[Motor](https://github.com/mongodb/motor) has been deprecated with final support ending on May 14th, 2027. #69 

This PR replaces usage of Motor (and ODMantic) in favor of PyMongo Async. Verified locally that `bash scripts/test.sh` still passes.