### PR TITLE
Bump pymongo version >= 4.13

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/backend/app/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "httpx>=0.21.0,<0.23.0",
   "psycopg2-binary>=2.9.5",
   "setuptools>=65.6.3",
-  "pymongo>=4.9",
+  "pymongo>=4.13",
   "pytest==7.4.2",
   "pytest-cov==4.1.0",
   "pytest-asyncio>=0.21.0",


### PR DESCRIPTION
pymongo=4.13 is the first production-ready version of the async API, see https://github.com/mongodb-labs/full-stack-fastapi-mongodb/pull/72#discussion_r3357973426